### PR TITLE
Fixing the disconnected buffer coming up too much

### DIFF
--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -233,7 +233,8 @@
             break;
           case WebSocket.OPEN:
             clearInterval(this.interval);
-            // if we've connected, we can wait for real empty event
+            // Default to connected, but lokinet is slow so we pretend empty event
+            this.onEmpty();
             this.interval = null;
             break;
           case WebSocket.CLOSING:

--- a/libtextsecure/http-resources.js
+++ b/libtextsecure/http-resources.js
@@ -64,7 +64,7 @@
     if (typeof handleRequest !== 'function') {
       handleRequest = request => request.respond(404, 'Not found');
     }
-    let connected = false;
+    let connected = true;
     const jobQueue = new window.JobQueue();
 
     const processMessages = async messages => {


### PR DESCRIPTION
Small fix for the disconnected banner coming up when it shouldn't, just default to thinking we are connected and mock the onEmpty event. Will only get set to not connected if requests fail

Fixes oxen-io/session-desktop-temp#1196 