### PR TITLE
Hook up channel encryption

### DIFF
--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -1,11 +1,13 @@
 /* eslint-disable no-await-in-loop */
 /* eslint-disable no-loop-func */
-/* global log, dcodeIO, window, callWorker, lokiP2pAPI, lokiSnodeAPI */
+/* global log, dcodeIO, window, callWorker, lokiP2pAPI, lokiSnodeAPI, libloki */
 
 const nodeFetch = require('node-fetch');
 const _ = require('lodash');
+const { parse } = require('url');
 
 const endpointBase = '/v1/storage_rpc';
+const LOKI_EPHEMKEY_HEADER = 'X-Loki-EphemKey';
 
 class HTTPError extends Error {
   constructor(response) {
@@ -27,6 +29,25 @@ const fetch = async (url, options = {}) => {
   const timeout = options.timeout || 10000;
   const method = options.method || 'GET';
 
+  const address = parse(url).hostname;
+  const doEncryptChannel =
+    address.endsWith('.snode') &&
+    options.headers &&
+    LOKI_EPHEMKEY_HEADER in options.headers;
+  if (doEncryptChannel) {
+    try {
+      // eslint-disable-next-line no-param-reassign
+      options.body = await libloki.crypto.snodeCipher.encrypt(
+        address,
+        options.body
+      );
+      // eslint-disable-next-line no-param-reassign
+      options.headers['Content-Type'] = 'text/plain';
+    } catch (e) {
+      log.warn(`Could not encrypt channel for ${address}: `, e);
+    }
+  }
+
   try {
     const response = await nodeFetch(url, {
       ...options,
@@ -45,6 +66,18 @@ const fetch = async (url, options = {}) => {
       result = await response.buffer();
     } else {
       result = await response.text();
+      if (doEncryptChannel) {
+        try {
+          result = await libloki.crypto.snodeCipher.decrypt(address, result);
+        } catch (e) {
+          log.warn(`Could not decrypt response from ${address}`, e);
+        }
+        try {
+          result = JSON.parse(result);
+        } catch(e) {
+          log.warn(`Could not parse string to json ${result}`, e);
+        }
+      }
     }
 
     return result;
@@ -151,7 +184,7 @@ class LokiMessageAPI {
         method: 'POST',
         body: JSON.stringify(body),
         headers: {
-          'X-Loki-EphemKey': 'not implemented yet',
+          [LOKI_EPHEMKEY_HEADER]: libloki.crypto.snodeCipher.getChannelPublicKeyHex(),
         },
       };
 
@@ -247,7 +280,7 @@ class LokiMessageAPI {
         },
       };
       const headers = {
-        'X-Loki-EphemKey': 'not implemented yet',
+        [LOKI_EPHEMKEY_HEADER]: libloki.crypto.snodeCipher.getChannelPublicKeyHex(),
       };
       const fetchOptions = {
         method: 'POST',

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -74,7 +74,7 @@ const fetch = async (url, options = {}) => {
         }
         try {
           result = JSON.parse(result);
-        } catch(e) {
+        } catch (e) {
           log.warn(`Could not parse string to json ${result}`, e);
         }
       }

--- a/libloki/test/snode_channel_test.js
+++ b/libloki/test/snode_channel_test.js
@@ -98,8 +98,14 @@ describe('Snode Channel', () => {
         senderPubKey,
         snodePrivKey
       );
-      const encryptedArrayBuffer = dcodeIO.ByteBuffer.wrap(encrypted, 'base64').toArrayBuffer();
-      const decrypted = await libloki.crypto.DHDecrypt(symmetricKey, encryptedArrayBuffer);
+      const encryptedArrayBuffer = dcodeIO.ByteBuffer.wrap(
+        encrypted,
+        'base64'
+      ).toArrayBuffer();
+      const decrypted = await libloki.crypto.DHDecrypt(
+        symmetricKey,
+        encryptedArrayBuffer
+      );
       const textDecoder = new TextDecoder();
       const messageReceived = textDecoder.decode(decrypted);
       assert.strictEqual(messageSent, messageReceived);
@@ -124,7 +130,9 @@ describe('Snode Channel', () => {
         snodePrivKey
       );
       const encrypted = await libloki.crypto.DHEncrypt(symmetricKey, data);
-      const encryptedBase64 = dcodeIO.ByteBuffer.wrap(encrypted).toString('base64');
+      const encryptedBase64 = dcodeIO.ByteBuffer.wrap(encrypted).toString(
+        'base64'
+      );
       // message received by Loki Messenger
       const decrypted = await channel.decrypt(snode.address, encryptedBase64);
       assert.strictEqual(messageSent, decrypted);

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "jquery": "3.3.1",
     "js-sha512": "0.8.0",
     "jsbn": "1.1.0",
+    "libsodium-wrappers": "^0.7.4",
     "linkify-it": "2.0.3",
     "lodash": "4.17.11",
     "mkdirp": "0.5.1",

--- a/preload.js
+++ b/preload.js
@@ -339,6 +339,13 @@ window.React = require('react');
 window.ReactDOM = require('react-dom');
 window.moment = require('moment');
 
+const _sodium = require('libsodium-wrappers');
+
+window.getSodium = async () => {
+  await _sodium.ready;
+  return _sodium;
+};
+
 window.clipboard = clipboard;
 
 const Signal = require('./js/modules/signal');

--- a/yarn.lock
+++ b/yarn.lock
@@ -758,13 +758,6 @@ balanced-match@^0.4.1, balanced-match@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
-base-x@3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.4.tgz#94c1788736da065edb1d68808869e357c977fa77"
-  integrity sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==
-  dependencies:
-    safe-buffer "^5.0.1"
-
 base64-js@^1.0.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.0.tgz#a39992d723584811982be5e290bb6a53d86700f1"
@@ -5081,6 +5074,18 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+libsodium-wrappers@^0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/libsodium-wrappers/-/libsodium-wrappers-0.7.4.tgz#cdb3ce6553e4864c0a68070c4313583489bd765d"
+  integrity sha512-axKkW01L0q+urLeE7UMSZKWwk4LrRbi6s5pjKBAvbgDBYnsSaolK1oN/Syilm1dqJFkJQNi6qodwOp8dzSoc9Q==
+  dependencies:
+    libsodium "0.7.4"
+
+libsodium@0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/libsodium/-/libsodium-0.7.4.tgz#a5bccd65e3a13b34147ea109be3c65d89f90b074"
+  integrity sha512-fTU3vUdrxQzhPAAjmTSqKk4LzYbR0OtcYjp1P92AlH50JIxXZFEIXWh1yryCmU6RLGfwS2IzBdZjbmpYf/TlyQ==
+
 lie@*:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lie/-/lie-3.2.0.tgz#4f13f2f8bbb027d383db338c43043545791aa8dc"
@@ -5723,13 +5728,6 @@ ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
-
-multibase@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/multibase/-/multibase-0.6.0.tgz#0216e350614c7456da5e8e5b20d3fcd4c9104f56"
-  integrity sha512-R9bNLQhbD7MsitPm1NeY7w9sDgu6d7cuj25snAWH7k5PSNPSwIQQBpcpj8jx1W96dLbdigZqmUWOdQRMnAmgjA==
-  dependencies:
-    base-x "3.0.4"
 
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Needed to use libsodium to convert ed25519 pubkey to a curve25519 pubkey.
The encrypted data is encoded as base64 and sent as `text/plain` instead of json.

Was able to send messages offline and via P2P between 2 local instances (using yarn start-multi, and after some tweaks to emulate talking to an snode).
Passes `yarn lint` and `yarn test`.
closes oxen-io/session-desktop-temp#1191 