### PR TITLE
Fix registration

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -203,6 +203,18 @@
   window.log.info('Storage fetch');
   storage.fetch();
 
+  const initAPIs = () => {
+    const ourKey = textsecure.storage.user.getNumber();
+    window.lokiMessageAPI = new window.LokiMessageAPI(ourKey);
+    window.lokiP2pAPI = new window.LokiP2pAPI(ourKey);
+    window.lokiP2pAPI.on('pingContact', pubKey => {
+      const isPing = true;
+      window.libloki.api.sendOnlineBroadcastMessage(pubKey, isPing);
+    });
+    window.lokiP2pAPI.on('online', ConversationController._handleOnline);
+    window.lokiP2pAPI.on('offline', ConversationController._handleOffline);
+  };
+
   function mapOldThemeToNew(theme) {
     switch (theme) {
       case 'dark':
@@ -233,17 +245,8 @@
 
     if (Whisper.Registration.isDone()) {
       startLocalLokiServer();
+      initAPIs();
     }
-
-    window.lokiP2pAPI = new window.LokiP2pAPI(
-      textsecure.storage.user.getNumber()
-    );
-    window.lokiP2pAPI.on('pingContact', pubKey => {
-      const isPing = true;
-      window.libloki.api.sendOnlineBroadcastMessage(pubKey, isPing);
-    });
-
-    window.lokiMessageAPI = new window.LokiMessageAPI();
 
     const currentPoWDifficulty = storage.get('PoWDifficulty', null);
     if (!currentPoWDifficulty) {
@@ -562,6 +565,7 @@
       //   logger: window.log,
       // });
 
+      initAPIs();
       connect(true);
     });
 

--- a/js/conversation_controller.js
+++ b/js/conversation_controller.js
@@ -1,4 +1,4 @@
-/* global _, Whisper, Backbone, storage, lokiP2pAPI, textsecure, libsignal */
+/* global _, Whisper, Backbone, storage, textsecure, libsignal */
 
 /* eslint-disable more/no-then */
 
@@ -218,14 +218,6 @@
     async load() {
       window.log.info('ConversationController: starting initial fetch');
 
-      // We setup online and offline listeners here because we want
-      //  to minimize the amount of listeners we have to avoid memory leaks
-      if (!this.p2pListenersSet) {
-        lokiP2pAPI.on('online', this._handleOnline.bind(this));
-        lokiP2pAPI.on('offline', this._handleOffline.bind(this));
-        this.p2pListenersSet = true;
-      }
-
       if (conversations.length) {
         throw new Error('ConversationController: Already loaded!');
       }
@@ -273,13 +265,13 @@
 
       return this._initialPromise;
     },
-    _handleOnline(pubKey) {
+    _handleOnline: pubKey => {
       try {
         const conversation = this.get(pubKey);
         conversation.set({ isOnline: true });
       } catch (e) {} // eslint-disable-line
     },
-    _handleOffline(pubKey) {
+    _handleOffline: pubKey => {
       try {
         const conversation = this.get(pubKey);
         conversation.set({ isOnline: false });

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -165,10 +165,15 @@
       this.typingRefreshTimer = null;
       this.typingPauseTimer = null;
 
-      // Online status handling
-      this.set({ isOnline: lokiP2pAPI.isOnline(this.id) });
       if (this.id === this.ourNumber) {
         this.set({ friendRequestStatus: FriendRequestStatusEnum.friends });
+      } else if (lokiP2pAPI) {
+        // Online status handling, only for contacts that aren't us
+        this.set({ isOnline: lokiP2pAPI.isOnline(this.id) });
+      } else {
+        window.log.warn(
+          'lokiP2pAPI not initialised when spawning conversation!'
+        );
       }
 
       this.messageSendQueue = new JobQueue();

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -67,10 +67,10 @@ const trySendP2p = async (pubKey, data64, isPing, messageEventData) => {
 };
 
 class LokiMessageAPI {
-  constructor() {
+  constructor(ourKey) {
     this.jobQueue = new window.JobQueue();
     this.sendingSwarmNodes = {};
-    this.ourKey = window.textsecure.storage.user.getNumber();
+    this.ourKey = ourKey;
   }
 
   async sendMessage(pubKey, data, messageTimeStamp, ttl, options = {}) {

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -14,8 +14,7 @@
     );
     await Promise.all(
       friendKeys.map(async pubKey => {
-        if (pubKey === textsecure.storage.user.getNumber())
-          return
+        if (pubKey === textsecure.storage.user.getNumber()) return;
         try {
           await sendOnlineBroadcastMessage(pubKey);
         } catch (e) {


### PR DESCRIPTION
Pass ourKey to message api, initialise these APIs after registration or when storage is ready so we always have ourKey
Don't try and set the online handler for a conversation with ourselves (mainly because this conversation is created before registration event so p2pAPI isn't available)