### PR TITLE
Fix release notes link

### DIFF
--- a/main.js
+++ b/main.js
@@ -417,7 +417,7 @@ ipc.on('ready-for-updates', async () => {
 
 function openReleaseNotes() {
   shell.openExternal(
-    `https://github.com/loki-project/loki-messenger/releases/tag/v${app.getVersion()}`
+    `https://github.com/loki-project/loki-messenger/releases/tag/${app.getVersion()}`
   );
 }
 


### PR DESCRIPTION
I think this was a bad update of an old signal link
fixes oxen-io/session-desktop-temp#1122 