### PR TITLE
Generate 13 word seeds by default - still accept 25 word seeds.

### DIFF
--- a/libtextsecure/account_manager.js
+++ b/libtextsecure/account_manager.js
@@ -523,7 +523,10 @@
       });
     },
     async generateMnemonic(language = 'english') {
-      const seed = window.Signal.Crypto.getRandomBytes(16);
+      // Note: 4 bytes are converted into 3 seed words, so length 12 seed words
+      // (13 - 1 checksum) are generated using 12 * 4 / 3 = 16 bytes.
+      const seedSize = 16;
+      const seed = window.Signal.Crypto.getRandomBytes(seedSize);
       const hex = StringView.arrayBufferToHex(seed);
       return mnemonic.mn_encode(hex, language);
     },

--- a/libtextsecure/account_manager.js
+++ b/libtextsecure/account_manager.js
@@ -125,9 +125,10 @@
         generateKeypair = () => {
           let seedHex = window.mnemonic.mn_decode(mnemonic, mnemonicLanguage);
           // handle shorter than 32 bytes seeds
-          if (seedHex.length !== 32 * 2) {
+          const privKeyHexLength = 32 * 2;
+          if (seedHex.length !== privKeyHexLength) {
             seedHex = seedHex.concat(seedHex);
-            seedHex = seedHex.substring(0, 32 * 2);
+            seedHex = seedHex.substring(0, privKeyHexLength);
           }
           const privKeyHex = window.mnemonic.sc_reduce32(seedHex);
           const privKey = dcodeIO.ByteBuffer.wrap(

--- a/libtextsecure/account_manager.js
+++ b/libtextsecure/account_manager.js
@@ -123,7 +123,12 @@
       let generateKeypair;
       if (mnemonic) {
         generateKeypair = () => {
-          const seedHex = window.mnemonic.mn_decode(mnemonic, mnemonicLanguage);
+          let seedHex = window.mnemonic.mn_decode(mnemonic, mnemonicLanguage);
+          // handle shorter than 32 bytes seeds
+          if (seedHex.length !== 32 * 2) {
+            seedHex = seedHex.concat(seedHex);
+            seedHex = seedHex.substring(0, 32 * 2);
+          }
           const privKeyHex = window.mnemonic.sc_reduce32(seedHex);
           const privKey = dcodeIO.ByteBuffer.wrap(
             privKeyHex,
@@ -517,8 +522,8 @@
       });
     },
     async generateMnemonic(language = 'english') {
-      const keys = await libsignal.KeyHelper.generateIdentityKeyPair();
-      const hex = StringView.arrayBufferToHex(keys.privKey);
+      const seed = window.Signal.Crypto.getRandomBytes(16);
+      const hex = StringView.arrayBufferToHex(seed);
       return mnemonic.mn_encode(hex, language);
     },
     getCurrentMnemonic() {


### PR DESCRIPTION
After some back and forth, this is simply reducing the seed length to 12 + 1, using the existing code and not bip39.
Generated mnemonic is 13 words (except for "electrum" word list, not sure why)
Restore from either 13 or 25 words works.
The private key is derived from the seed by duplicating the bytes, in a similar fashion as lokid.