### PR TITLE
Fix the conversation horizontal scrollbar when only few conversations #560

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -3306,6 +3306,7 @@
   flex-grow: 1;
   flex-shrink: 1;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .module-left-pane__virtual-list {

--- a/ts/components/LeftPane.tsx
+++ b/ts/components/LeftPane.tsx
@@ -237,7 +237,7 @@ export class LeftPane extends React.Component<Props, any> {
               rowHeight={64}
               rowRenderer={this.renderRow}
               width={width}
-              autoHeight
+              autoHeight={true}
             />
           )}
         </AutoSizer>

--- a/ts/components/LeftPane.tsx
+++ b/ts/components/LeftPane.tsx
@@ -237,6 +237,7 @@ export class LeftPane extends React.Component<Props, any> {
               rowHeight={64}
               rowRenderer={this.renderRow}
               width={width}
+              autoHeight
             />
           )}
         </AutoSizer>


### PR DESCRIPTION
### First time contributor checklist:

* [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

* [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
* [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [ ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
* [X] My changes are ready to be shipped to users

**Yarn ready does not pass but I do not think it comes from this issue:** 

```
 /Pro/contribs/loki-messenger/js/modules/loki_file_server_api.js
233:43  error  'DEVICE_MAPPING_ANNOTATION_KEY' is not defined  no-undef
```

### Description
Do not show a vertical scrollbar when there are not enough conversations in the conversation list.
Fixes oxen-io/session-desktop-temp#1037 

Tested manually, screenshots provided.

Tested on Linux 64-bit (Debian)

Attached, some screenshots of before and after behavior.
**Before**: even if only 3 items in the list, when the dropdown menu is shown the list shows a scrollbar (the list does not resize):
![before](https://user-images.githubusercontent.com/1544279/69516331-72e74100-0fa5-11ea-921e-b366df6fce9f.png)

**After**: the scrollbar is not visible when not enough items are on the list and the dropdown menu is shown;
![after](https://user-images.githubusercontent.com/1544279/69516337-767ac800-0fa5-11ea-9b35-931fee737b8e.png)

**After**: the vertical scrollbar works as expected and the horizontal one is no longer visible:
![after2](https://user-images.githubusercontent.com/1544279/69519355-fad14900-0fad-11ea-8152-80760b21af85.png)
