### PR TITLE
Change onChange to onAfterchage

### DIFF
--- a/ts/components/session/settings/SessionSettingListItem.tsx
+++ b/ts/components/session/settings/SessionSettingListItem.tsx
@@ -95,7 +95,7 @@ export class SessionSettingListItem extends React.Component<Props, State> {
                 min={content.min}
                 max={content.max}
                 defaultValue={currentSliderValue}
-                onChange={sliderValue => {
+                onAfterChange={sliderValue => {
                   this.handleSlider(sliderValue);
                 }}
               />


### PR DESCRIPTION
### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/development) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

Fixes oxen-io/session-desktop-temp#886 

I changed onChange to onAfterChange on SettingsSlider, because if the zoom-factor updates the courser switches between two values which causes the GUI to freak out.
The change has no effect on other settings utilizing the SettingsSlider to configure.