### PR TITLE
Add a numeric TTL Countdown if the time left is under 1 minute

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -653,11 +653,14 @@
 
 // Module: Expire Timer
 
+.module-expire-timer-margin {
+  margin-left: 6px;
+}
+
 .module-expire-timer {
   width: 12px;
   height: 12px;
   display: inline-block;
-  margin-left: 6px;
   margin-bottom: 2px;
   @include color-svg('../images/timer-60.svg', $color-gray-60);
 }

--- a/ts/components/conversation/ExpireTimer.tsx
+++ b/ts/components/conversation/ExpireTimer.tsx
@@ -47,11 +47,27 @@ export class ExpireTimer extends React.Component<Props> {
     } = this.props;
 
     const bucket = getTimerBucket(expirationTimestamp, expirationLength);
+    let timeLeft = Math.round((expirationTimestamp - Date.now()) / 1000);
+    timeLeft = timeLeft >= 0 ? timeLeft : 0;
+    if (timeLeft <= 60) {
+      return (
+        <span
+          className={classNames(
+            'module-expire-timer-margin',
+            'module-message__metadata__date',
+            `module-message__metadata__date--${direction}`
+          )}
+        >
+          {timeLeft}
+        </span>
+      );
+    }
 
     return (
       <div
         className={classNames(
           'module-expire-timer',
+          'module-expire-timer-margin',
           `module-expire-timer--${bucket}`,
           `module-expire-timer--${direction}`,
           withImageNoCaption


### PR DESCRIPTION
### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/development) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description
Closes oxen-io/session-desktop-temp#911 
Add a numeric TTL Countdown if the time left is under 1 minute because it could increase productivity. 