### PR TITLE
force ubuntu 18.04 for workflows (issue with glibc being too recent)

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2016, macos-latest, ubuntu-latest]
+        os: [windows-2016, macos-latest, ubuntu-18.04]
     env:
       SIGNAL_ENV: production
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2016, macos-latest, ubuntu-latest]
+        os: [windows-2016, macos-latest, ubuntu-18.04]
     env:
       SIGNAL_ENV: production
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2016, macos-latest, ubuntu-latest]
+        os: [windows-2016, macos-latest, ubuntu-18.04]
     env:
       SIGNAL_ENV: production
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "session-desktop",
   "productName": "Session",
   "description": "Private messaging from your desktop",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "license": "GPL-3.0",
   "author": {
     "name": "Loki Project",


### PR DESCRIPTION
 force ubuntu-18.04 for github actions

building on ubuntu 20.04 was causing issue with a too recent glibc for
some users dependent on ubuntu 18.04 or similar (elementary OS)
The issue arise as github action ubuntu-latest was upgraded recently too
ubuntu 20.04.
This fix forces the app to be built on ubuntu 18.04