### PR TITLE
add the request and reply of an encryptionKeyPair if needed

### DIFF
--- a/app/sql.js
+++ b/app/sql.js
@@ -171,6 +171,7 @@ module.exports = {
   getAllEncryptionKeyPairsForGroup,
   getLatestClosedGroupEncryptionKeyPair,
   addClosedGroupEncryptionKeyPair,
+  isKeyPairAlreadySaved,
   removeAllClosedGroupEncryptionKeyPairs,
 };
 
@@ -3264,6 +3265,18 @@ async function addClosedGroupEncryptionKeyPair(
       $timestamp: timestamp,
       $json: objectToJSON(keypair),
     }
+  );
+}
+
+async function isKeyPairAlreadySaved(
+  groupPublicKey,
+  newKeyPairInHex // : HexKeyPair
+) {
+  const allKeyPairs = await getAllEncryptionKeyPairsForGroup(groupPublicKey);
+  return (allKeyPairs || []).some(
+    k =>
+      newKeyPairInHex.publicHex === k.publicHex &&
+      newKeyPairInHex.privateHex === k.privateHex
   );
 }
 

--- a/js/modules/data.d.ts
+++ b/js/modules/data.d.ts
@@ -1,5 +1,6 @@
 import { KeyPair } from '../../libtextsecure/libsignal-protocol';
 import { HexKeyPair } from '../../ts/receiver/closedGroups';
+import { ECKeyPair } from '../../ts/receiver/keypairs';
 import { PubKey } from '../../ts/session/types';
 import { ConversationType } from '../../ts/state/ducks/conversations';
 import { Message } from '../../ts/types/Message';
@@ -401,6 +402,10 @@ export function removeAllClosedGroupRatchets(groupId: string): Promise<void>;
 export function getAllEncryptionKeyPairsForGroup(
   groupPublicKey: string | PubKey
 ): Promise<Array<HexKeyPair> | undefined>;
+export function isKeyPairAlreadySaved(
+  groupPublicKey: string,
+  keypair: HexKeyPair
+): Promise<boolean>;
 export function getLatestClosedGroupEncryptionKeyPair(
   groupPublicKey: string
 ): Promise<HexKeyPair | undefined>;

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -196,6 +196,7 @@ module.exports = {
   getAllEncryptionKeyPairsForGroup,
   getLatestClosedGroupEncryptionKeyPair,
   addClosedGroupEncryptionKeyPair,
+  isKeyPairAlreadySaved,
   removeAllClosedGroupEncryptionKeyPairs,
 };
 
@@ -721,6 +722,10 @@ async function getLatestClosedGroupEncryptionKeyPair(groupPublicKey) {
 
 async function addClosedGroupEncryptionKeyPair(groupPublicKey, keypair) {
   return channels.addClosedGroupEncryptionKeyPair(groupPublicKey, keypair);
+}
+
+async function isKeyPairAlreadySaved(groupPublicKey, keypair) {
+  return channels.isKeyPairAlreadySaved(groupPublicKey, keypair);
 }
 
 async function removeAllClosedGroupEncryptionKeyPairs(groupPublicKey) {

--- a/libloki/crypto.d.ts
+++ b/libloki/crypto.d.ts
@@ -10,7 +10,6 @@ export interface CryptoInterface {
   EncryptGCM: any; // AES-GCM
   PairingType: PairingTypeEnum;
   _decodeSnodeAddressToPubKey: any;
-  decryptForPubkey: any;
   decryptToken: any;
   encryptForPubkey: any;
   generateEphemeralKeyPair: any;

--- a/libloki/crypto.js
+++ b/libloki/crypto.js
@@ -69,14 +69,6 @@
     return { ciphertext, symmetricKey, ephemeralKey: ephemeral.pubKey };
   }
 
-  async function decryptForPubkey(seckeyX25519, ephemKey, ciphertext) {
-    const symmetricKey = await deriveSymmetricKey(ephemKey, seckeyX25519);
-
-    const plaintext = await DecryptGCM(symmetricKey, ciphertext);
-
-    return plaintext;
-  }
-
   async function EncryptGCM(symmetricKey, plaintext) {
     const nonce = crypto.getRandomValues(new Uint8Array(NONCE_LENGTH));
 
@@ -187,7 +179,6 @@
     PairingType,
     generateEphemeralKeyPair,
     encryptForPubkey,
-    decryptForPubkey,
     _decodeSnodeAddressToPubKey: decodeSnodeAddressToPubKey,
     sha512,
   };

--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -156,13 +156,14 @@ message DataMessage {
   message ClosedGroupControlMessage {
 
 	  enum Type {
-	    NEW                 = 1; // publicKey, name, encryptionKeyPair, members, admins
-	    UPDATE              = 2; // name, members
-      ENCRYPTION_KEY_PAIR = 3; // wrappers
-      NAME_CHANGE         = 4; // name
-      MEMBERS_ADDED       = 5; // members
-      MEMBERS_REMOVED     = 6; // members
-      MEMBER_LEFT         = 7;
+	    NEW                           = 1; // publicKey, name, encryptionKeyPair, members, admins
+	    UPDATE                        = 2; // name, members
+      ENCRYPTION_KEY_PAIR           = 3; // publicKey, wrappers
+      NAME_CHANGE                   = 4; // name
+      MEMBERS_ADDED                 = 5; // members
+      MEMBERS_REMOVED               = 6; // members
+      MEMBER_LEFT                   = 7;
+      ENCRYPTION_KEY_PAIR_REQUEST   = 8;
 	  }
 
 

--- a/ts/receiver/cache.ts
+++ b/ts/receiver/cache.ts
@@ -54,7 +54,7 @@ export async function getAllFromCache() {
       const attempts = _.toNumber(item.attempts || 0) + 1;
 
       try {
-        if (attempts >= 3) {
+        if (attempts >= 10) {
           window.log.warn(
             'getAllFromCache final attempt for envelope',
             item.id

--- a/ts/receiver/cache.ts
+++ b/ts/receiver/cache.ts
@@ -4,6 +4,7 @@ import _ from 'lodash';
 
 export async function removeFromCache(envelope: EnvelopePlus) {
   const { id } = envelope;
+  window.log.info(`removing from cache envelope: ${id}`);
 
   return window.textsecure.storage.unprocessed.remove(id);
 }

--- a/ts/receiver/cache.ts
+++ b/ts/receiver/cache.ts
@@ -31,9 +31,7 @@ export async function addToCache(
   return window.textsecure.storage.unprocessed.add(data);
 }
 
-export async function getAllFromCache() {
-  window.log.info('getAllFromCache');
-
+async function fetchAllFromCache(): Promise<Array<any>> {
   const { textsecure } = window;
 
   const count = await textsecure.storage.unprocessed.getCount();
@@ -47,7 +45,59 @@ export async function getAllFromCache() {
   }
 
   const items = await textsecure.storage.unprocessed.getAll();
+  return items;
+}
+
+export async function getAllFromCache() {
+  window.log.info('getAllFromCache');
+  const items = await fetchAllFromCache();
+
   window.log.info('getAllFromCache loaded', items.length, 'saved envelopes');
+  const { textsecure } = window;
+
+  return Promise.all(
+    _.map(items, async (item: any) => {
+      const attempts = _.toNumber(item.attempts || 0) + 1;
+
+      try {
+        if (attempts >= 10) {
+          window.log.warn(
+            'getAllFromCache final attempt for envelope',
+            item.id
+          );
+          await textsecure.storage.unprocessed.remove(item.id);
+        } else {
+          await textsecure.storage.unprocessed.updateAttempts(
+            item.id,
+            attempts
+          );
+        }
+      } catch (error) {
+        window.log.error(
+          'getAllFromCache error updating item after load:',
+          error && error.stack ? error.stack : error
+        );
+      }
+
+      return item;
+    })
+  );
+}
+
+export async function getAllFromCacheForSource(source: string) {
+  const items = await fetchAllFromCache();
+
+  // keep items without source too (for old message already added to the cache)
+  const itemsFromSource = items.filter(
+    item => !!item.senderIdentity || item.senderIdentity === source
+  );
+
+  window.log.info(
+    'getAllFromCacheForSource loaded',
+    itemsFromSource.length,
+    'saved envelopes'
+  );
+  const { textsecure } = window;
 
   return Promise.all(
     _.map(items, async (item: any) => {

--- a/ts/receiver/closedGroups.ts
+++ b/ts/receiver/closedGroups.ts
@@ -29,8 +29,8 @@ import { ConversationModel } from '../../js/models/conversations';
 import _ from 'lodash';
 import { forceSyncConfigurationNowIfNeeded } from '../session/utils/syncUtils';
 import { MessageController } from '../session/messages';
-import { ClosedGroupEncryptionPairMessage } from '../session/messages/outgoing';
 import { ClosedGroupEncryptionPairReplyMessage } from '../session/messages/outgoing/content/data/group';
+import { queueAllCachedFromSource } from './receiver';
 
 export async function handleClosedGroupControlMessage(
   envelope: EnvelopePlus,
@@ -250,6 +250,8 @@ export async function handleNewClosedGroup(
   window.SwarmPolling.addGroupId(PubKey.cast(groupId));
 
   await removeFromCache(envelope);
+  // trigger decrypting of all this group messages we did not decrypt successfully yet.
+  await queueAllCachedFromSource(groupId);
 }
 
 async function handleUpdateClosedGroup(
@@ -465,6 +467,8 @@ async function handleClosedGroupEncryptionKeyPair(
 
   await addClosedGroupEncryptionKeyPair(groupPublicKey, keyPair.toHexKeyPair());
   await removeFromCache(envelope);
+  // trigger decrypting of all this group messages we did not decrypt successfully yet.
+  await queueAllCachedFromSource(groupPublicKey);
 }
 
 async function performIfValid(

--- a/ts/receiver/closedGroups.ts
+++ b/ts/receiver/closedGroups.ts
@@ -16,6 +16,7 @@ import {
   addClosedGroupEncryptionKeyPair,
   getAllEncryptionKeyPairsForGroup,
   getLatestClosedGroupEncryptionKeyPair,
+  isKeyPairAlreadySaved,
   removeAllClosedGroupEncryptionKeyPairs,
 } from '../../js/modules/data';
 import {
@@ -449,16 +450,12 @@ async function handleClosedGroupEncryptionKeyPair(
   // Store it if needed
   const newKeyPairInHex = keyPair.toHexKeyPair();
 
-  const keyPairsAlreadySaved = await getAllEncryptionKeyPairsForGroup(
-    groupPublicKey
-  );
-  const isKeyPairAlreadySaved = (keyPairsAlreadySaved || []).some(
-    k =>
-      newKeyPairInHex.publicHex === k.publicHex &&
-      newKeyPairInHex.privateHex === k.privateHex
+  const isKeyPairAlreadyHere = await isKeyPairAlreadySaved(
+    groupPublicKey,
+    newKeyPairInHex
   );
 
-  if (isKeyPairAlreadySaved) {
+  if (isKeyPairAlreadyHere) {
     window.log.info('Dropping already saved keypair for group', groupPublicKey);
     await removeFromCache(envelope);
     return;

--- a/ts/receiver/contentMessage.ts
+++ b/ts/receiver/contentMessage.ts
@@ -531,8 +531,7 @@ export async function handleConfigurationMessage(
   if (!ourPubkey) {
     return;
   }
-  console.warn('ourPubkey', ourPubkey);
-  console.warn('envelope.source', envelope.source);
+
   if (envelope.source !== ourPubkey) {
     window?.log?.info(
       'Dropping configuration change from someone else than us.'

--- a/ts/receiver/contentMessage.ts
+++ b/ts/receiver/contentMessage.ts
@@ -15,6 +15,8 @@ import { ConversationController } from '../session/conversations';
 import { getAllEncryptionKeyPairsForGroup } from '../../js/modules/data';
 import { ECKeyPair } from './keypairs';
 import { handleNewClosedGroup } from './closedGroups';
+import { KeyPairRequestManager } from './keyPairRequestManager';
+import { requestEncryptionKeyPair } from '../session/group';
 
 export async function handleContentMessage(envelope: EnvelopePlus) {
   try {
@@ -59,6 +61,10 @@ async function decryptForClosedGroup(
     // likely be the one we want) but try older ones in case that didn't work)
     let decryptedContent: ArrayBuffer | undefined;
     let keyIndex = 0;
+
+    // If an error happens in here, we catch it in the inner try-catch
+    // When the loop is done, we check if the decryption is a success;
+    // If not, we trigger a new Error which will trigger in the outer try-catch
     do {
       try {
         const hexEncryptionKeyPair = encryptionKeyPairs.pop();
@@ -88,7 +94,6 @@ async function decryptForClosedGroup(
     } while (encryptionKeyPairs.length > 0);
 
     if (!decryptedContent?.byteLength) {
-      await removeFromCache(envelope);
       throw new Error(
         `Could not decrypt message for closed group with any of the ${encryptionKeyPairsCount} keypairs.`
       );
@@ -105,10 +110,23 @@ async function decryptForClosedGroup(
 
     return unpad(decryptedContent);
   } catch (e) {
+    /**
+     * If an error happened during the decoding,
+     * we trigger a request to get the latest EncryptionKeyPair for this medium group.
+     * Indeed, we might not have the latest one used by someone else, or not have any keypairs for this group.
+     *
+     */
+
     window.log.warn(
       'decryptWithSessionProtocol for medium group message throw:',
       e
     );
+    const keypairRequestManager = KeyPairRequestManager.getInstance();
+    const groupPubKey = PubKey.cast(envelope.source);
+    if (keypairRequestManager.canTriggerRequestWith(groupPubKey)) {
+      keypairRequestManager.markRequestSendFor(groupPubKey, Date.now());
+      await requestEncryptionKeyPair(groupPubKey);
+    }
     await removeFromCache(envelope);
     return null;
   }
@@ -269,8 +287,6 @@ async function decrypt(
   envelope: EnvelopePlus,
   ciphertext: ArrayBuffer
 ): Promise<any> {
-  const { textsecure } = window;
-
   try {
     const plaintext = await doDecrypt(envelope, ciphertext);
 

--- a/ts/receiver/contentMessage.ts
+++ b/ts/receiver/contentMessage.ts
@@ -127,7 +127,12 @@ async function decryptForClosedGroup(
       keypairRequestManager.markRequestSendFor(groupPubKey, Date.now());
       await requestEncryptionKeyPair(groupPubKey);
     }
-    await removeFromCache(envelope);
+    throw new Error(
+      `Waiting for an encryption keypair to be received for group ${groupPubKey.key}`
+    );
+    // do not remove it from the cache yet. We will try to decrypt it once we get the encryption keypair
+    // TODO drop it if after some time we still don't get to decrypt it
+    // await removeFromCache(envelope);
     return null;
   }
 }

--- a/ts/receiver/keyPairRequestManager.ts
+++ b/ts/receiver/keyPairRequestManager.ts
@@ -1,0 +1,47 @@
+import { PubKey } from '../session/types';
+import { SECONDS } from '../session/utils/Number';
+
+/**
+ * Singleton handling the logic behing requesting EncryptionKeypair for a closed group we need.
+ *
+ * Nothing is read/written to the db, it's all on memory for now.
+ */
+export class KeyPairRequestManager {
+  public static DELAY_BETWEEN_TWO_REQUEST_MS = SECONDS * 30;
+  private static instance: KeyPairRequestManager | null;
+  private readonly requestTimestamps: Map<string, number>;
+
+  private constructor() {
+    this.requestTimestamps = new Map();
+  }
+
+  public static getInstance() {
+    if (KeyPairRequestManager.instance) {
+      return KeyPairRequestManager.instance;
+    }
+    KeyPairRequestManager.instance = new KeyPairRequestManager();
+    return KeyPairRequestManager.instance;
+  }
+
+  public reset() {
+    this.requestTimestamps.clear();
+  }
+
+  public markRequestSendFor(pubkey: PubKey, timestamp: number) {
+    this.requestTimestamps.set(pubkey.key, timestamp);
+  }
+
+  public get(pubkey: PubKey) {
+    return this.requestTimestamps.get(pubkey.key);
+  }
+
+  public canTriggerRequestWith(pubkey: PubKey) {
+    const record = this.requestTimestamps.get(pubkey.key);
+    if (!record) {
+      return true;
+    }
+
+    const now = Date.now();
+    return now - record >= KeyPairRequestManager.DELAY_BETWEEN_TWO_REQUEST_MS;
+  }
+}

--- a/ts/receiver/receiver.ts
+++ b/ts/receiver/receiver.ts
@@ -3,7 +3,12 @@
 import { EnvelopePlus } from './types';
 export { downloadAttachment } from './attachments';
 
-import { addToCache, getAllFromCache, removeFromCache } from './cache';
+import {
+  addToCache,
+  getAllFromCache,
+  getAllFromCacheForSource,
+  removeFromCache,
+} from './cache';
 import { processMessage } from '../session/snode_api/swarmPolling';
 import { onError } from './errors';
 
@@ -184,6 +189,13 @@ export async function handleRequest(
 
 export async function queueAllCached() {
   const items = await getAllFromCache();
+  items.forEach(async item => {
+    await queueCached(item);
+  });
+}
+
+export async function queueAllCachedFromSource(source: string) {
+  const items = await getAllFromCacheForSource(source);
   items.forEach(async item => {
     await queueCached(item);
   });

--- a/ts/session/group/index.ts
+++ b/ts/session/group/index.ts
@@ -29,6 +29,7 @@ import { UserUtils } from '../utils';
 import { ClosedGroupMemberLeftMessage } from '../messages/outgoing/content/data/group/ClosedGroupMemberLeftMessage';
 import {
   ClosedGroupAddedMembersMessage,
+  ClosedGroupEncryptionPairRequestMessage,
   ClosedGroupNameChangeMessage,
   ClosedGroupRemovedMembersMessage,
   ClosedGroupUpdateMessage,
@@ -556,26 +557,10 @@ export async function generateAndSendNewEncryptionKeyPair(
     );
     return;
   }
-  const proto = new SignalService.KeyPair({
-    privateKey: newKeyPair?.privateKeyData,
-    publicKey: newKeyPair?.publicKeyData,
-  });
-  const plaintext = SignalService.KeyPair.encode(proto).finish();
-
   // Distribute it
-  const wrappers = await Promise.all(
-    targetMembers.map(async pubkey => {
-      const ciphertext = await encryptUsingSessionProtocol(
-        PubKey.cast(pubkey),
-        plaintext
-      );
-      return new SignalService.DataMessage.ClosedGroupControlMessage.KeyPairWrapper(
-        {
-          encryptedKeyPair: ciphertext,
-          publicKey: fromHexToArray(pubkey),
-        }
-      );
-    })
+  const wrappers = await buildEncryptionKeyPairWrappers(
+    targetMembers,
+    newKeyPair
   );
 
   const expireTimer = groupConvo.get('expireTimer') || 0;
@@ -597,6 +582,75 @@ export async function generateAndSendNewEncryptionKeyPair(
       newKeyPair.toHexKeyPair()
     );
   };
-
+  // this is to be sent to the group pubkey adress
   await getMessageQueue().sendToGroup(keypairsMessage, messageSentCallback);
+}
+
+export async function buildEncryptionKeyPairWrappers(
+  targetMembers: Array<string>,
+  encryptionKeyPair: ECKeyPair
+) {
+  if (
+    !encryptionKeyPair ||
+    !encryptionKeyPair.publicKeyData.length ||
+    !encryptionKeyPair.privateKeyData.length
+  ) {
+    throw new Error(
+      'buildEncryptionKeyPairWrappers() needs a valid encryptionKeyPair set'
+    );
+  }
+
+  const proto = new SignalService.KeyPair({
+    privateKey: encryptionKeyPair?.privateKeyData,
+    publicKey: encryptionKeyPair?.publicKeyData,
+  });
+  const plaintext = SignalService.KeyPair.encode(proto).finish();
+
+  const wrappers = await Promise.all(
+    targetMembers.map(async pubkey => {
+      const ciphertext = await encryptUsingSessionProtocol(
+        PubKey.cast(pubkey),
+        plaintext
+      );
+      return new SignalService.DataMessage.ClosedGroupControlMessage.KeyPairWrapper(
+        {
+          encryptedKeyPair: ciphertext,
+          publicKey: fromHexToArray(pubkey),
+        }
+      );
+    })
+  );
+  return wrappers;
+}
+
+export async function requestEncryptionKeyPair(
+  groupPublicKey: string | PubKey
+) {
+  const groupConvo = ConversationController.getInstance().get(
+    PubKey.cast(groupPublicKey).key
+  );
+
+  if (!groupConvo) {
+    window.log.warn(
+      'requestEncryptionKeyPair: Trying to request encryption key pair from unknown group'
+    );
+    return;
+  }
+
+  const ourNumber = await UserUtils.getOurNumber();
+  if (!groupConvo.get('members').includes(ourNumber.key)) {
+    window.log.info(
+      'requestEncryptionKeyPair: We are not a member of this group.'
+    );
+    return;
+  }
+  const expireTimer = groupConvo.get('expireTimer') || 0;
+
+  const ecRequestMessage = new ClosedGroupEncryptionPairRequestMessage({
+    expireTimer,
+    groupId: groupPublicKey,
+    timestamp: Date.now(),
+  });
+
+  await getMessageQueue().sendToGroup(ecRequestMessage);
 }

--- a/ts/session/messages/outgoing/content/data/group/ClosedGroupEncryptionPairMessage.ts
+++ b/ts/session/messages/outgoing/content/data/group/ClosedGroupEncryptionPairMessage.ts
@@ -1,11 +1,12 @@
 import { Constants } from '../../../../..';
 import { SignalService } from '../../../../../../protobuf';
+import { fromHexToArray } from '../../../../../utils/String';
 import {
   ClosedGroupMessage,
   ClosedGroupMessageParams,
 } from './ClosedGroupMessage';
 
-interface ClosedGroupEncryptionPairMessageParams
+export interface ClosedGroupEncryptionPairMessageParams
   extends ClosedGroupMessageParams {
   encryptedKeyPairs: Array<
     SignalService.DataMessage.ClosedGroupControlMessage.KeyPairWrapper

--- a/ts/session/messages/outgoing/content/data/group/ClosedGroupEncryptionPairReplyMessage.ts
+++ b/ts/session/messages/outgoing/content/data/group/ClosedGroupEncryptionPairReplyMessage.ts
@@ -1,0 +1,25 @@
+import { SignalService } from '../../../../../../protobuf';
+import { fromHexToArray } from '../../../../../utils/String';
+import { ClosedGroupEncryptionPairMessage } from './ClosedGroupEncryptionPairMessage';
+
+/**
+ * On Desktop, we need separate class for message being sent to a closed group or a private chat.
+ *
+ * This is because we use the class of the message to know what encryption to use.
+ * See toRawMessage();
+ *
+ * This class is just used to let us send the encryption key par after we receivied a ENCRYPTION_KEYPAIR_REQUEST
+ *  from a member of a group.
+ * This reply must be sent to this user's pubkey, and so be encoded using sessionProtocol.
+ */
+export class ClosedGroupEncryptionPairReplyMessage extends ClosedGroupEncryptionPairMessage {
+  public dataProto(): SignalService.DataMessage {
+    const dataMessage = super.dataProto();
+    // tslint:disable: no-non-null-assertion
+    dataMessage.closedGroupControlMessage!.publicKey = fromHexToArray(
+      this.groupId.key
+    );
+
+    return dataMessage;
+  }
+}

--- a/ts/session/messages/outgoing/content/data/group/ClosedGroupEncryptionPairRequestMessage.ts
+++ b/ts/session/messages/outgoing/content/data/group/ClosedGroupEncryptionPairRequestMessage.ts
@@ -1,0 +1,19 @@
+import { Constants } from '../../../../..';
+import { SignalService } from '../../../../../../protobuf';
+import { ClosedGroupMessage } from './ClosedGroupMessage';
+
+export class ClosedGroupEncryptionPairRequestMessage extends ClosedGroupMessage {
+  public dataProto(): SignalService.DataMessage {
+    const dataMessage = super.dataProto();
+
+    // tslint:disable: no-non-null-assertion
+    dataMessage.closedGroupControlMessage!.type =
+      SignalService.DataMessage.ClosedGroupControlMessage.Type.ENCRYPTION_KEY_PAIR_REQUEST;
+
+    return dataMessage;
+  }
+
+  public ttl(): number {
+    return Constants.TTL_DEFAULT.ENCRYPTION_PAIR_GROUP;
+  }
+}

--- a/ts/session/messages/outgoing/content/data/group/index.ts
+++ b/ts/session/messages/outgoing/content/data/group/index.ts
@@ -1,5 +1,7 @@
 export * from './ClosedGroupChatMessage';
 export * from './ClosedGroupEncryptionPairMessage';
+export * from './ClosedGroupEncryptionPairRequestMessage';
+export * from './ClosedGroupEncryptionPairReplyMessage';
 export * from './ClosedGroupNewMessage';
 export * from './ClosedGroupAddedMembersMessage';
 export * from './ClosedGroupNameChangeMessage';

--- a/ts/session/sending/MessageQueue.ts
+++ b/ts/session/sending/MessageQueue.ts
@@ -6,6 +6,7 @@ import {
 } from './MessageQueueInterface';
 import {
   ChatMessage,
+  ClosedGroupNewMessage,
   ContentMessage,
   DataMessage,
   ExpirationTimerUpdateMessage,
@@ -40,8 +41,7 @@ export class MessageQueue implements MessageQueueInterface {
     ) {
       throw new Error('SyncMessage needs to be sent with sendSyncMessage');
     }
-
-    await this.sendMessageToDevices([user], message);
+    await this.process(user, message, sentCb);
   }
 
   public async send(
@@ -55,7 +55,7 @@ export class MessageQueue implements MessageQueueInterface {
     ) {
       throw new Error('SyncMessage needs to be sent with sendSyncMessage');
     }
-    await this.sendMessageToDevices([device], message, sentCb);
+    await this.process(device, message, sentCb);
   }
 
   /**
@@ -136,7 +136,7 @@ export class MessageQueue implements MessageQueueInterface {
       throw new Error('ourNumber is not set');
     }
 
-    await this.sendMessageToDevices([PubKey.cast(ourPubKey)], message, sentCb);
+    await this.process(PubKey.cast(ourPubKey), message, sentCb);
   }
 
   public async processPending(device: PubKey) {
@@ -172,18 +172,6 @@ export class MessageQueue implements MessageQueueInterface {
     });
   }
 
-  public async sendMessageToDevices(
-    devices: Array<PubKey>,
-    message: ContentMessage,
-    sentCb?: (message: RawMessage) => Promise<void>
-  ) {
-    const promises = devices.map(async device => {
-      await this.process(device, message, sentCb);
-    });
-
-    return Promise.all(promises);
-  }
-
   private async processAllPending() {
     const devices = await this.pendingMessageCache.getDevices();
     const promises = devices.map(async device => this.processPending(device));
@@ -191,6 +179,9 @@ export class MessageQueue implements MessageQueueInterface {
     return Promise.all(promises);
   }
 
+  /**
+   * This method should not be called directly. Only through sendToPubKey.
+   */
   private async process(
     device: PubKey,
     message: ContentMessage,
@@ -199,9 +190,11 @@ export class MessageQueue implements MessageQueueInterface {
     // Don't send to ourselves
     const currentDevice = await UserUtils.getCurrentDevicePubKey();
     if (currentDevice && device.isEqual(currentDevice)) {
-      // We allow a message for ourselve only if it's a ConfigurationMessage or a message with a syncTarget set
+      // We allow a message for ourselve only if it's a ConfigurationMessage, a ClosedGroupNewMessage,
+      // or a message with a syncTarget set.
       if (
         message instanceof ConfigurationMessage ||
+        message instanceof ClosedGroupNewMessage ||
         (message as any).syncTarget?.length > 0
       ) {
         window.log.warn('Processing sync message');

--- a/ts/session/sending/MessageQueueInterface.ts
+++ b/ts/session/sending/MessageQueueInterface.ts
@@ -2,13 +2,30 @@ import { ContentMessage, OpenGroupMessage } from '../messages/outgoing';
 import { RawMessage } from '../types/RawMessage';
 import { TypedEventEmitter } from '../utils';
 import { PubKey } from '../types';
-import { ClosedGroupMessage } from '../messages/outgoing/content/data/group/ClosedGroupMessage';
 import { ClosedGroupChatMessage } from '../messages/outgoing/content/data/group/ClosedGroupChatMessage';
+import {
+  ClosedGroupAddedMembersMessage,
+  ClosedGroupEncryptionPairMessage,
+  ClosedGroupNameChangeMessage,
+  ClosedGroupRemovedMembersMessage,
+  ClosedGroupUpdateMessage,
+} from '../messages/outgoing/content/data/group';
+import { ClosedGroupMemberLeftMessage } from '../messages/outgoing/content/data/group/ClosedGroupMemberLeftMessage';
+import { ClosedGroupEncryptionPairRequestMessage } from '../messages/outgoing/content/data/group/ClosedGroupEncryptionPairRequestMessage';
 
 export type GroupMessageType =
   | OpenGroupMessage
   | ClosedGroupChatMessage
-  | ClosedGroupMessage;
+  | ClosedGroupAddedMembersMessage
+  | ClosedGroupRemovedMembersMessage
+  | ClosedGroupNameChangeMessage
+  | ClosedGroupMemberLeftMessage
+  | ClosedGroupUpdateMessage
+  | ClosedGroupEncryptionPairMessage
+  | ClosedGroupEncryptionPairRequestMessage;
+
+// ClosedGroupEncryptionPairReplyMessage must be sent to a user pubkey. Not a group.
+
 export interface MessageQueueInterfaceEvents {
   sendSuccess: (
     message: RawMessage | OpenGroupMessage,

--- a/ts/session/utils/Messages.ts
+++ b/ts/session/utils/Messages.ts
@@ -16,12 +16,16 @@ import { getLatestClosedGroupEncryptionKeyPair } from '../../../js/modules/data'
 import { UserUtils } from '.';
 import { ECKeyPair } from '../../receiver/keypairs';
 import _ from 'lodash';
+import { ClosedGroupEncryptionPairReplyMessage } from '../messages/outgoing/content/data/group/ClosedGroupEncryptionPairReplyMessage';
 
-export function getEncryptionTypeFromMessageType(
+function getEncryptionTypeFromMessageType(
   message: ContentMessage
 ): EncryptionType {
   // ClosedGroupNewMessage is sent using established channels, so using fallback
-  if (message instanceof ClosedGroupNewMessage) {
+  if (
+    message instanceof ClosedGroupNewMessage ||
+    message instanceof ClosedGroupEncryptionPairReplyMessage
+  ) {
     return EncryptionType.Fallback;
   }
 

--- a/ts/test/session/unit/messages/ConfigurationMessage_test.ts
+++ b/ts/test/session/unit/messages/ConfigurationMessage_test.ts
@@ -5,7 +5,6 @@ import {
   ConfigurationMessage,
   ConfigurationMessageClosedGroup,
 } from '../../../../session/messages/outgoing/content/ConfigurationMessage';
-import { PubKey } from '../../../../session/types';
 import { TestUtils } from '../../../test-utils';
 
 describe('ConfigurationMessage', () => {

--- a/ts/test/session/unit/receiving/ConfigurationMessage_test.ts
+++ b/ts/test/session/unit/receiving/ConfigurationMessage_test.ts
@@ -1,0 +1,93 @@
+import { SignalService } from '../../../../protobuf';
+import { handleConfigurationMessage } from '../../../../receiver/contentMessage';
+import chai from 'chai';
+
+import { ConfigurationMessage } from '../../../../session/messages/outgoing/content/ConfigurationMessage';
+import { UserUtils } from '../../../../session/utils';
+import { TestUtils } from '../../../test-utils';
+
+import Sinon, * as sinon from 'sinon';
+import * as cache from '../../../../receiver/cache';
+import * as data from '../../../../../js/modules/data';
+import { EnvelopePlus } from '../../../../receiver/types';
+
+// tslint:disable-next-line: no-require-imports no-var-requires
+const chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+chai.should();
+
+const { expect } = chai;
+
+describe('ConfigurationMessage_receiving', () => {
+  const sandbox = sinon.createSandbox();
+  let createOrUpdateStub: Sinon.SinonStub<any>;
+  let getItemByIdStub: Sinon.SinonStub<any>;
+  let sender: string;
+
+  let envelope: EnvelopePlus;
+  let config: ConfigurationMessage;
+
+  beforeEach(() => {
+    sandbox.stub(cache, 'removeFromCache').resolves();
+    sender = TestUtils.generateFakePubKey().key;
+    config = new ConfigurationMessage({
+      activeOpenGroups: [],
+      activeClosedGroups: [],
+      timestamp: Date.now(),
+      identifier: 'whatever',
+    });
+  });
+
+  afterEach(() => {
+    TestUtils.restoreStubs();
+    sandbox.restore();
+  });
+
+  it('should not be processed if we do not have a pubkey', async () => {
+    sandbox.stub(UserUtils, 'getCurrentDevicePubKey').resolves(undefined);
+    envelope = TestUtils.generateEnvelopePlus(sender);
+
+    const proto = config.contentProto();
+    createOrUpdateStub = sandbox.stub(data, 'createOrUpdateItem').resolves();
+    getItemByIdStub = sandbox.stub(data, 'getItemById').resolves();
+    await handleConfigurationMessage(
+      envelope,
+      proto.configurationMessage as SignalService.ConfigurationMessage
+    );
+    expect(createOrUpdateStub.callCount).to.equal(0);
+    expect(getItemByIdStub.callCount).to.equal(0);
+  });
+
+  describe('with ourNumber set', () => {
+    const ourNumber = TestUtils.generateFakePubKey().key;
+
+    beforeEach(() => {
+      sandbox.stub(UserUtils, 'getCurrentDevicePubKey').resolves(ourNumber);
+    });
+
+    it('should not be processed if the message is not coming from our number', async () => {
+      const proto = config.contentProto();
+      // sender !== ourNumber
+      envelope = TestUtils.generateEnvelopePlus(sender);
+
+      createOrUpdateStub = sandbox.stub(data, 'createOrUpdateItem').resolves();
+      getItemByIdStub = sandbox.stub(data, 'getItemById').resolves();
+      await handleConfigurationMessage(
+        envelope,
+        proto.configurationMessage as SignalService.ConfigurationMessage
+      );
+      expect(createOrUpdateStub.callCount).to.equal(0);
+      expect(getItemByIdStub.callCount).to.equal(0);
+    });
+
+    // it('should be processed if the message is coming from our number', async () => {
+    //     const proto = config.contentProto();
+    //     envelope = TestUtils.generateEnvelopePlus(ourNumber);
+
+    //     createOrUpdateStub = sandbox.stub(data, 'createOrUpdateItem').resolves();
+    //     getItemByIdStub = sandbox.stub(data, 'getItemById').resolves();
+    //     await handleConfigurationMessage(envelope, proto.configurationMessage as SignalService.ConfigurationMessage);
+    //     expect(getItemByIdStub.callCount).to.equal(1);
+    // });
+  });
+});

--- a/ts/test/session/unit/receiving/KeyPairRequestManager_test.ts
+++ b/ts/test/session/unit/receiving/KeyPairRequestManager_test.ts
@@ -1,0 +1,81 @@
+import chai from 'chai';
+// tslint:disable: no-require-imports no-var-requires no-implicit-dependencies
+
+import _ from 'lodash';
+import { describe } from 'mocha';
+import { KeyPairRequestManager } from '../../../../receiver/keyPairRequestManager';
+import { TestUtils } from '../../../test-utils';
+
+const chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+
+chai.should();
+const { expect } = chai;
+
+// tslint:disable-next-line: max-func-body-length
+describe('KeyPairRequestManager', () => {
+  let inst: KeyPairRequestManager;
+  beforeEach(() => {
+    KeyPairRequestManager.getInstance().reset();
+    inst = KeyPairRequestManager.getInstance();
+  });
+
+  it('getInstance() should return an instance', () => {
+    expect(inst).to.exist;
+  });
+
+  describe('markRequestSendFor', () => {
+    it('should be able to set a timestamp for a pubkey', () => {
+      const groupPubkey = TestUtils.generateFakePubKey();
+      const now = Date.now();
+      inst.markRequestSendFor(groupPubkey, now);
+      expect(inst.get(groupPubkey)).to.be.equal(now);
+    });
+
+    it('should be able to override a timestamp for a pubkey', () => {
+      const groupPubkey = TestUtils.generateFakePubKey();
+      const timestamp1 = Date.now();
+      inst.markRequestSendFor(groupPubkey, timestamp1);
+      expect(inst.get(groupPubkey)).to.be.equal(timestamp1);
+      const timestamp2 = Date.now() + 1000;
+      inst.markRequestSendFor(groupPubkey, timestamp2);
+      expect(inst.get(groupPubkey)).to.be.equal(timestamp2);
+    });
+  });
+
+  describe('canTriggerRequestWith', () => {
+    it('should return true if there is no timestamp set for this pubkey', () => {
+      const groupPubkey = TestUtils.generateFakePubKey();
+      const can = inst.canTriggerRequestWith(groupPubkey);
+      expect(can).to.be.equal(
+        true,
+        'should return true if we there is no timestamp set for this pubkey'
+      );
+    });
+
+    it('should return false if there is a timestamp set for this pubkey and it is less than DELAY_BETWEEN_TWO_REQUEST_MS', () => {
+      const groupPubkey = TestUtils.generateFakePubKey();
+      const timestamp1 = Date.now();
+
+      inst.markRequestSendFor(groupPubkey, timestamp1);
+      const can = inst.canTriggerRequestWith(groupPubkey);
+      expect(can).to.be.equal(
+        false,
+        'return false if there is a timestamp set for this pubkey and it is less than DELAY_BETWEEN_TWO_REQUEST_MS'
+      );
+    });
+
+    it('should return true if there is a timestamp set for this pubkey and it is more than DELAY_BETWEEN_TWO_REQUEST_MS', () => {
+      const groupPubkey = TestUtils.generateFakePubKey();
+      const timestamp1 =
+        Date.now() - KeyPairRequestManager.DELAY_BETWEEN_TWO_REQUEST_MS;
+
+      inst.markRequestSendFor(groupPubkey, timestamp1);
+      const can = inst.canTriggerRequestWith(groupPubkey);
+      expect(can).to.be.equal(
+        true,
+        'true if there is a timestamp set for this pubkey and it is more than DELAY_BETWEEN_TWO_REQUEST_MS'
+      );
+    });
+  });
+});

--- a/ts/test/session/unit/sending/MessageQueue_test.ts
+++ b/ts/test/session/unit/sending/MessageQueue_test.ts
@@ -141,27 +141,15 @@ describe('MessageQueue', () => {
 
   describe('sendToPubKey', () => {
     it('should send the message to the device', async () => {
-      const devices = TestUtils.generateFakePubKeys(1);
-      const stub = sandbox
-        .stub(messageQueueStub, 'sendMessageToDevices')
-        .resolves();
+      const device = TestUtils.generateFakePubKey();
+      const stub = sandbox.stub(messageQueueStub as any, 'process').resolves();
 
       const message = TestUtils.generateChatMessage();
-      await messageQueueStub.sendToPubKey(devices[0], message);
+      await messageQueueStub.sendToPubKey(device, message);
 
       const args = stub.lastCall.args as [Array<PubKey>, ContentMessage];
-      expect(args[0]).to.have.same.members(devices);
+      expect(args[0]).to.be.equal(device);
       expect(args[1]).to.equal(message);
-    });
-  });
-
-  describe('sendMessageToDevices', () => {
-    it('can send to many devices', async () => {
-      const devices = TestUtils.generateFakePubKeys(5);
-      const message = TestUtils.generateChatMessage();
-
-      await messageQueueStub.sendMessageToDevices(devices, message);
-      expect(pendingMessageCache.getCache()).to.have.length(devices.length);
     });
   });
 

--- a/ts/test/session/unit/utils/Messages_test.ts
+++ b/ts/test/session/unit/utils/Messages_test.ts
@@ -17,6 +17,7 @@ import {
 import { ConversationModel } from '../../../../../js/models/conversations';
 import { MockConversation } from '../../../test-utils/utils';
 import { ConfigurationMessage } from '../../../../session/messages/outgoing/content/ConfigurationMessage';
+import { ClosedGroupEncryptionPairReplyMessage } from '../../../../session/messages/outgoing/content/data/group/ClosedGroupEncryptionPairReplyMessage';
 // tslint:disable-next-line: no-require-imports no-var-requires
 const chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
@@ -185,7 +186,7 @@ describe('Message Utils', () => {
       expect(rawMessage.encryption).to.equal(EncryptionType.ClosedGroup);
     });
 
-    it('passing ClosedGroupEncryptionPairMessage returns ClosedGroup', async () => {
+    it('passing ClosedGroupEncryptionKeyPairReply returns Fallback', async () => {
       const device = TestUtils.generateFakePubKey();
 
       const fakeWrappers = new Array<
@@ -197,14 +198,14 @@ describe('Message Utils', () => {
           encryptedKeyPair: new Uint8Array(8),
         })
       );
-      const msg = new ClosedGroupEncryptionPairMessage({
+      const msg = new ClosedGroupEncryptionPairReplyMessage({
         timestamp: Date.now(),
         groupId: TestUtils.generateFakePubKey().key,
         encryptedKeyPairs: fakeWrappers,
         expireTimer: 0,
       });
       const rawMessage = await MessageUtils.toRawMessage(device, msg);
-      expect(rawMessage.encryption).to.equal(EncryptionType.ClosedGroup);
+      expect(rawMessage.encryption).to.equal(EncryptionType.Fallback);
     });
 
     it('passing a ConfigurationMessage returns Fallback', async () => {

--- a/ts/test/test-utils/utils/envelope.ts
+++ b/ts/test/test-utils/utils/envelope.ts
@@ -22,6 +22,21 @@ export function generateEnvelopePlusClosedGroup(
   return envelope;
 }
 
+export function generateEnvelopePlus(sender: string): EnvelopePlus {
+  const envelope: EnvelopePlus = {
+    receivedAt: Date.now(),
+    timestamp: Date.now() - 2000,
+    id: uuid(),
+    type: SignalService.Envelope.Type.UNIDENTIFIED_SENDER,
+    source: sender,
+    senderIdentity: sender,
+    content: new Uint8Array(),
+    toJSON: () => ['fake'],
+  };
+
+  return envelope;
+}
+
 export function generateGroupUpdateNameChange(
   groupId: string
 ): SignalService.DataMessage.ClosedGroupControlMessage {


### PR DESCRIPTION
Fixed the closed group logic 
[x] Be able to request an keypair if we somehow lost it but are still a member of the group.
[x] only handle the first configuration message incoming
[x] self-send closed group updates of type new