### PR TITLE
Replace unused textResponse with used noJson, updating logging

### DIFF
--- a/js/modules/loki_app_dot_net_api.js
+++ b/js/modules/loki_app_dot_net_api.js
@@ -287,7 +287,7 @@ const serverRequest = async (endpoint, options = {}) => {
 
       txtResponse = await result.text();
       // cloudflare timeouts (504s) will be html...
-      response = options.textResponse ? txtResponse : JSON.parse(txtResponse);
+      response = options.noJson ? txtResponse : JSON.parse(txtResponse);
 
       // result.status will always be 200
       // emulate the correct http code if available
@@ -303,7 +303,7 @@ const serverRequest = async (endpoint, options = {}) => {
         e.message,
         `json: ${txtResponse}`,
         'attempting connection to',
-        url
+        url.toString()
       );
     } else {
       log.error(
@@ -311,7 +311,7 @@ const serverRequest = async (endpoint, options = {}) => {
         e.code,
         e.message,
         'attempting connection to',
-        url
+        url.toString()
       );
     }
 


### PR DESCRIPTION
This fixes open groups to be able to get a token when onion requests fail.

submit_challenge API returns a 200 with no text, so the JSON.parse would fail (even though noJson option was set)

Also cleans up the logging output a bit to be useful.