### PR TITLE
Allow pasting images into composition box as attachments

### DIFF
--- a/ts/components/session/conversation/SessionCompositionBox.tsx
+++ b/ts/components/session/conversation/SessionCompositionBox.tsx
@@ -203,7 +203,7 @@ export class SessionCompositionBox extends React.Component<Props, State> {
   private handlePaste(e: any) {
     const { items } = e.clipboardData;
     let imgBlob = null;
-    for (const item of items.length) {
+    for (const item of items) {
       if (item.type.split('/')[0] === 'image') {
         imgBlob = item.getAsFile();
       }

--- a/ts/components/session/conversation/SessionCompositionBox.tsx
+++ b/ts/components/session/conversation/SessionCompositionBox.tsx
@@ -153,12 +153,19 @@ export class SessionCompositionBox extends React.Component<Props, State> {
 
   public componentDidMount() {
     setTimeout(this.focusCompositionBox, 100);
+
+    const div = this.container
+    div?.addEventListener("paste", this.handlePaste) 
   }
 
   public componentWillUnmount() {
     this.abortLinkPreviewFetch();
     this.linkPreviewAbortController = undefined;
+
+    const div = this.container
+    div?.removeEventListener("paste", this.handlePaste) 
   }
+
   public componentDidUpdate(prevProps: Props, _prevState: State) {
     // reset the state on new conversation key
     if (prevProps.selectedConversationKey !== this.props.selectedConversationKey) {
@@ -191,6 +198,24 @@ export class SessionCompositionBox extends React.Component<Props, State> {
     }
 
     this.hideEmojiPanel();
+  }
+
+  private handlePaste(e: any) {
+    const { items } = e.clipboardData;
+    let imgBlob = null;
+    for (let i = 0; i < items.length; i += 1) {
+      if (items[i].type.split('/')[0] === 'image') {
+        imgBlob = items[i].getAsFile();
+      }
+    }
+    if (imgBlob !== null) {
+      const file = imgBlob;
+      window.log.info("Adding attachment from clipboard", file)
+      void this.props.onChoseAttachments([file]);
+
+      e.preventDefault();
+      e.stopPropagation();
+    }
   }
 
   private showEmojiPanel() {

--- a/ts/components/session/conversation/SessionCompositionBox.tsx
+++ b/ts/components/session/conversation/SessionCompositionBox.tsx
@@ -154,16 +154,16 @@ export class SessionCompositionBox extends React.Component<Props, State> {
   public componentDidMount() {
     setTimeout(this.focusCompositionBox, 100);
 
-    const div = this.container
-    div?.addEventListener("paste", this.handlePaste) 
+    const div = this.container;
+    div?.addEventListener('paste', this.handlePaste);
   }
 
   public componentWillUnmount() {
     this.abortLinkPreviewFetch();
     this.linkPreviewAbortController = undefined;
 
-    const div = this.container
-    div?.removeEventListener("paste", this.handlePaste) 
+    const div = this.container;
+    div?.removeEventListener('paste', this.handlePaste);
   }
 
   public componentDidUpdate(prevProps: Props, _prevState: State) {
@@ -203,15 +203,15 @@ export class SessionCompositionBox extends React.Component<Props, State> {
   private handlePaste(e: any) {
     const { items } = e.clipboardData;
     let imgBlob = null;
-    for (let i = 0; i < items.length; i += 1) {
-      if (items[i].type.split('/')[0] === 'image') {
-        imgBlob = items[i].getAsFile();
+    for (const item of items.length) {
+      if (item.type.split('/')[0] === 'image') {
+        imgBlob = item.getAsFile();
       }
     }
     if (imgBlob !== null) {
       const file = imgBlob;
-      window.log.info("Adding attachment from clipboard", file)
-      void this.props.onChoseAttachments([file]);
+      window.log.info('Adding attachment from clipboard', file);
+      this.props.onChoseAttachments([file]);
 
       e.preventDefault();
       e.stopPropagation();


### PR DESCRIPTION
### First time contributor checklist:

* [x] I have read the [README](https://github.com/loki-project/loki-messenger/blob/master/README.md) and [Contributor Guidelines](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md)

### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [ ] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch (no changes since forked, I think this is okay? if not I'll fix it)
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

Allows the pasting of an image from the clipboard into the composition box as an attachment, as referenced in [#1600](https://github.com/oxen-io/session-desktop-temp/issues/688), [#1265](https://github.com/oxen-io/session-desktop-temp/issues/814), [#1583](https://github.com/oxen-io/session-desktop-temp/issues/692). Tested on Debian Bullseye 10.2.1-6, also used an Android 10 device running LineageOS 17.1 to check that attachments were received.
