### PR TITLE
Hiden shortened pubkey of message's author unless its an open group chat.

### DIFF
--- a/ts/components/ConversationListItem.tsx
+++ b/ts/components/ConversationListItem.tsx
@@ -229,7 +229,7 @@ class ConversationListItem extends React.PureComponent<Props> {
     const displayName = isMe ? i18n('noteToSelf') : profileName;
 
     let shouldShowPubkey = false;
-    if (!name || name.length === 0) {
+    if ((!name || name.length === 0) && (!displayName || displayName.length === 0)) {
       shouldShowPubkey = true;
     }
 


### PR DESCRIPTION
No longer shows the (...pubkey) text for a conversation list items and contact list items.
