### PR TITLE
add pn server dev url fallback to v2/lsrpc

### DIFF
--- a/ts/pushnotification/PnServer.ts
+++ b/ts/pushnotification/PnServer.ts
@@ -2,7 +2,10 @@ import { serverRequest } from '../session/onions/onionSend';
 import { fromArrayBufferToBase64 } from '../session/utils/String';
 
 const pnServerPubkeyHex = '642a6585919742e5a2d4dc51244964fbcd8bcab2b75612407de58b810740d049';
-const pnServerUrl = 'https://live.apns.getsession.org';
+
+export const hrefPnServerProd = 'live.apns.getsession.org';
+export const hrefPnServerDev = 'dev.apns.getsession.org';
+const pnServerUrl = `https://${hrefPnServerProd}`;
 
 export async function notify(plainTextBuffer: ArrayBuffer, sentTo: string) {
   const options = {

--- a/ts/session/snode_api/onions.ts
+++ b/ts/session/snode_api/onions.ts
@@ -13,6 +13,7 @@ import { fromBase64ToArrayBuffer, toHex } from '../utils/String';
 import pRetry from 'p-retry';
 import { incrementBadPathCountOrDrop } from '../onions/onionPath';
 import _ from 'lodash';
+import { hrefPnServerDev, hrefPnServerProd } from '../../pushnotification/PnServer';
 // hold the ed25519 key of a snode against the time it fails. Used to remove a snode only after a few failures (snodeFailureThreshold failures)
 let snodeFailureCount: Record<string, number> = {};
 
@@ -117,7 +118,8 @@ async function buildOnionCtxs(
     if (relayingToFinalDestination && finalRelayOptions) {
       let target = '/loki/v2/lsrpc';
 
-      const isCallToPn = finalRelayOptions?.host === 'live.apns.getsession.org';
+      const isCallToPn =
+        finalRelayOptions?.host === hrefPnServerDev || finalRelayOptions?.host === hrefPnServerProd;
       if (!isCallToPn && window.lokiFeatureFlags.useFileOnionRequestsV2) {
         target = '/loki/v3/lsrpc';
       }


### PR DESCRIPTION
the dev pn server is not used in the app, this change is just here to
not have to think of switching this part too when debugging against the
pn dev server