### PR TITLE
Transparent pngs

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -138,18 +138,14 @@
 .module-message--outgoing {
   .module-message__attachment-container--with-content-below,
   .module-message__attachment-container--with-content-above {
-    @include themify($themes) {
-      background: themed('sentMessageBackground');
-    }
+    background: none;
   }
 }
 
 .module-message--incoming {
   .module-message__attachment-container--with-content-below,
   .module-message__attachment-container--with-content-above {
-    @include themify($themes) {
-      background: themed('receivedMessageBackground');
-    }
+    background: none;
   }
 }
 

--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -130,9 +130,6 @@
   border-radius: $session_message-container-border-radius;
   overflow: hidden;
   // no background by default for the attachment container
-  @include themify($themes) {
-    background: themed('inboxBackground');
-  }
 }
 
 .module-message--outgoing {
@@ -1280,7 +1277,8 @@
 
 .module-image {
   overflow: hidden;
-  background-color: $color-white;
+  // background-color: $color-white;
+  background-color: rgba(0, 0, 0, 0);
   position: relative;
   display: inline-block;
   margin: 1px;

--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -1277,8 +1277,7 @@
 
 .module-image {
   overflow: hidden;
-  // background-color: $color-white;
-  background-color: rgba(0, 0, 0, 0);
+  background: none;
   position: relative;
   display: inline-block;
   margin: 1px;

--- a/stylesheets/_session_theme.scss
+++ b/stylesheets/_session_theme.scss
@@ -25,8 +25,14 @@
   }
 
   &__container--incoming {
-    @include themify($themes) {
-      background: themed('receivedMessageBackground');
+    &--opaque {
+      @include themify($themes) {
+        background: themed('receivedMessageBackground');
+      }
+    }
+
+    &--transparent {
+      background: none;
     }
 
     .module-message__text {

--- a/stylesheets/_session_theme.scss
+++ b/stylesheets/_session_theme.scss
@@ -49,8 +49,14 @@
   }
 
   &__container--outgoing {
-    @include themify($themes) {
-      background: themed('sentMessageBackground');
+    &--opaque {
+      @include themify($themes) {
+        background: themed('sentMessageBackground');
+      }
+    }
+
+    &--transparent {
+      background: none;
     }
 
     .module-message__text {

--- a/stylesheets/_theme_dark.scss
+++ b/stylesheets/_theme_dark.scss
@@ -401,7 +401,7 @@
   // Module: Image
 
   .module-image {
-    background-color: $color-black;
+    background: none;
   }
 
   .module-image__border-overlay {

--- a/ts/components/conversation/Message.tsx
+++ b/ts/components/conversation/Message.tsx
@@ -781,7 +781,10 @@ class MessageInner extends React.PureComponent<MessageRegularProps, State> {
           <div
             className={classNames(
               'module-message__container',
-              `module-message__container--${direction}`
+              `module-message__container--${direction}`,
+              isShowingImage
+                ? `module-message__container--${direction}--transparent`
+                : `module-message__container--${direction}--opaque`
             )}
             style={{
               width: isShowingImage ? width : undefined,


### PR DESCRIPTION
Outgoing/incoming image attachment messages no longer have a background so the image transparency reaches the conversation screen. Changed the background of the parent element for the example. Aqua message showing white is a jpg without transparency.

![transparent](https://user-images.githubusercontent.com/24505032/126247399-d3aa4b46-4b26-4b2a-9ce4-a67a70e1fe81.png)
