### PR TITLE
Fix for name change and adding members in groups

### DIFF
--- a/ts/components/session/conversation/SessionRightPanel.tsx
+++ b/ts/components/session/conversation/SessionRightPanel.tsx
@@ -122,7 +122,7 @@ const HeaderItem = () => {
     avatarPath,
     isPublic,
     id,
-    weAreAdmin,
+    isGroup,
     isKickedFromGroup,
     profileName,
     phoneNumber,
@@ -131,7 +131,7 @@ const HeaderItem = () => {
     name,
   } = selectedConversation;
 
-  const showInviteContacts = !isKickedFromGroup && !isBlocked && !left;
+  const showInviteContacts = isGroup && !isKickedFromGroup && !isBlocked && !left;
   const userName = name || profileName || phoneNumber;
 
   return (
@@ -249,7 +249,7 @@ export const SessionRightPanelWithDetails = () => {
     };
   });
 
-  const showUpdateGroupNameButton = (!isPublic || isPublic && weAreAdmin) && !commonNoShow;
+  const showUpdateGroupNameButton = isGroup && (!isPublic || isPublic && weAreAdmin) && !commonNoShow;
   const showAddRemoveModeratorsButton = weAreAdmin && !commonNoShow && isPublic;
 
 

--- a/ts/components/session/conversation/SessionRightPanel.tsx
+++ b/ts/components/session/conversation/SessionRightPanel.tsx
@@ -249,10 +249,9 @@ export const SessionRightPanelWithDetails = () => {
     };
   });
 
-  const showUpdateGroupNameButton = isGroup && (!isPublic || isPublic && weAreAdmin) && !commonNoShow;
+  const showUpdateGroupNameButton =
+    isGroup && (!isPublic || (isPublic && weAreAdmin)) && !commonNoShow;
   const showAddRemoveModeratorsButton = weAreAdmin && !commonNoShow && isPublic;
-
-
   const showUpdateGroupMembersButton = !isPublic && isGroup && !commonNoShow;
 
   const deleteConvoAction = isPublic

--- a/ts/components/session/conversation/SessionRightPanel.tsx
+++ b/ts/components/session/conversation/SessionRightPanel.tsx
@@ -131,7 +131,7 @@ const HeaderItem = () => {
     name,
   } = selectedConversation;
 
-  const showInviteContacts = (isPublic || weAreAdmin) && !isKickedFromGroup && !isBlocked && !left;
+  const showInviteContacts = !isKickedFromGroup && !isBlocked && !left;
   const userName = name || profileName || phoneNumber;
 
   return (
@@ -249,8 +249,9 @@ export const SessionRightPanelWithDetails = () => {
     };
   });
 
-  const showUpdateGroupNameButton = weAreAdmin && !commonNoShow;
+  const showUpdateGroupNameButton = (!isPublic || isPublic && weAreAdmin) && !commonNoShow;
   const showAddRemoveModeratorsButton = weAreAdmin && !commonNoShow && isPublic;
+
 
   const showUpdateGroupMembersButton = !isPublic && isGroup && !commonNoShow;
 

--- a/ts/models/conversation.ts
+++ b/ts/models/conversation.ts
@@ -1110,7 +1110,7 @@ export class ConversationModel extends Backbone.Model<ConversationAttributes> {
   }
 
   public isAdmin(pubKey?: string) {
-    if (!this.isPublic()) {
+    if (!this.isPublic() && !this.isGroup()) {
       return false;
     }
     if (!pubKey) {


### PR DESCRIPTION
Fix for the issues:
- Add members and edit name buttons weren't displayed in groups
- isAdmin function in conversation.ts was always returning false for closed groups