### PR TITLE
Media access check for MacOS

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -7,5 +7,9 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
   </dict>
 </plist>

--- a/js/background.js
+++ b/js/background.js
@@ -5,6 +5,7 @@
   storage,
   Whisper,
   BlockedNumberController,
+  Signal
 */
 
 // eslint-disable-next-line func-names
@@ -336,8 +337,11 @@
       window.libsession.Utils.ToastUtils.pushSpellCheckDirty();
     };
 
-    window.toggleMediaPermissions = () => {
+    window.toggleMediaPermissions = async () => {
       const value = window.getMediaPermissions();
+      if (value === false && Signal.OS.isMacOS()) {
+        await window.askForMicrophoneAccess();
+      }
       window.setMediaPermissions(!value);
     };
 

--- a/js/background.js
+++ b/js/background.js
@@ -340,7 +340,7 @@
     window.toggleMediaPermissions = async () => {
       const value = window.getMediaPermissions();
       if (value === false && Signal.OS.isMacOS()) {
-        await window.askForMicrophoneAccess();
+        await window.askForMediaAccess();
       }
       window.setMediaPermissions(!value);
     };

--- a/main.js
+++ b/main.js
@@ -25,6 +25,7 @@ const {
   protocol: electronProtocol,
   session,
   shell,
+  systemPreferences,
 } = electron;
 
 // FIXME Hardcoding appId to prevent build failrues on release.
@@ -983,3 +984,14 @@ function getThemeFromMainWindow() {
     mainWindow.webContents.send('get-theme-setting');
   });
 }
+
+function askForMicrophoneAccess() {
+  const status = systemPreferences.getMediaAccessStatus('microphone');
+  if (status !== 'granted') {
+    systemPreferences.askForMediaAccess('microphone');
+  }
+}
+
+ipc.on('microphone-access', () => {
+  askForMicrophoneAccess();
+});

--- a/main.js
+++ b/main.js
@@ -985,13 +985,19 @@ function getThemeFromMainWindow() {
   });
 }
 
-function askForMicrophoneAccess() {
-  const status = systemPreferences.getMediaAccessStatus('microphone');
+function askForMediaAccess() {
+  // Microphone part
+  let status = systemPreferences.getMediaAccessStatus('microphone');
   if (status !== 'granted') {
     systemPreferences.askForMediaAccess('microphone');
   }
+  // Camera part
+  status = systemPreferences.getMediaAccessStatus('camera');
+  if (status !== 'granted') {
+    systemPreferences.askForMediaAccess('camera');
+  }
 }
 
-ipc.on('microphone-access', () => {
-  askForMicrophoneAccess();
+ipc.on('media-access', () => {
+  askForMediaAccess();
 });

--- a/package.json
+++ b/package.json
@@ -236,7 +236,11 @@
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "entitlements": "build/entitlements.mac.plist",
-      "entitlementsInherit": "build/entitlements.mac.plist"
+      "entitlementsInherit": "build/entitlements.mac.plist",
+      "extendInfo": {
+        "NSCameraUsageDescription": "Session requires camera access to record video.",
+        "NSMicrophoneUsageDescription": "Session requires microphone access to record audio."
+      }
     },
     "dmg": {
       "sign": false

--- a/preload.js
+++ b/preload.js
@@ -219,6 +219,8 @@ window.setSettingValue = (settingID, value) => {
 window.getMediaPermissions = () => ipc.sendSync('get-media-permissions');
 window.setMediaPermissions = value => ipc.send('set-media-permissions', !!value);
 
+window.askForMicrophoneAccess = () => ipc.send('microphone-access');
+
 // Auto update setting
 window.getAutoUpdateEnabled = () => ipc.sendSync('get-auto-update-setting');
 window.setAutoUpdateEnabled = value => ipc.send('set-auto-update-setting', !!value);

--- a/preload.js
+++ b/preload.js
@@ -219,7 +219,7 @@ window.setSettingValue = (settingID, value) => {
 window.getMediaPermissions = () => ipc.sendSync('get-media-permissions');
 window.setMediaPermissions = value => ipc.send('set-media-permissions', !!value);
 
-window.askForMicrophoneAccess = () => ipc.send('microphone-access');
+window.askForMediaAccess = () => ipc.send('media-access');
 
 // Auto update setting
 window.getAutoUpdateEnabled = () => ipc.sendSync('get-auto-update-setting');

--- a/ts/components/session/settings/SessionSettings.tsx
+++ b/ts/components/session/settings/SessionSettings.tsx
@@ -253,11 +253,13 @@ class SettingsViewInner extends React.Component<SettingsViewProps, State> {
     return (
       <div className="session-settings__version-info">
         <span className="text-selectable">v{window.versionInfo.version}</span>
-        <span><SessionIconButton
-          iconSize={SessionIconSize.Medium}
-          iconType={SessionIconType.Oxen}
-          onClick={openOxenWebsite}
-        /></span>
+        <span>
+          <SessionIconButton
+            iconSize={SessionIconSize.Medium}
+            iconType={SessionIconType.Oxen}
+            onClick={openOxenWebsite}
+          />
+        </span>
         <span className="text-selectable">{window.versionInfo.commitHash}</span>
       </div>
     );


### PR DESCRIPTION
Media access wasn't granted for MacOS.
This PR allows user to give permission to Session to access the microphone and camera.

The popup will display once when the user turns on the setting in the privacy settings.

For users that already have it turned on, they'll need to disable and re-enable it to display the system popups.