### PR TITLE
'Ban user and delete all messages' added to menu

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -255,6 +255,8 @@
   "userUnbanFailed": "Unban failed!",
   "banUser": "Ban User",
   "banUserConfirm": "Are you sure you want to ban the user?",
+  "banUserAndDeleteAll": "Ban and Delete All",
+  "banUserAndDeleteAllConfirm": "Are you sure you want to ban the user and delete all his messages?",
   "userBanned": "Banned successfully",
   "userBanFailed": "Ban failed!",
   "leaveGroup": "Leave Group",

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -260,6 +260,8 @@
   "userUnbanFailed": "Le débannissement a échoué !",
   "banUser": "Bannir l'utilisateur",
   "banUserConfirm": "Êtes-vous sûr de vouloir bannir cet utilisateur ?",
+  "banUserAndDeleteAll": "Bannir et tout supprimer",
+  "banUserAndDeleteAllConfirm": "Êtes-vous sûr de vouloir bannir cet utilisateur et supprimer tous ses messages ?",
   "userBanned": "Utilisateur banni",
   "userBanFailed": "Le bannissement a échoué",
   "leaveGroup": "Quitter le groupe",

--- a/ts/components/conversation/MessageContextMenu.tsx
+++ b/ts/components/conversation/MessageContextMenu.tsx
@@ -131,6 +131,10 @@ export const MessageContextMenu = (props: PropsForMessageContextMenu) => {
     MessageInteraction.banUser(authorPhoneNumber, convoId);
   }, [authorPhoneNumber, convoId]);
 
+  const onBanAndDeleteAll = useCallback(() => {
+    MessageInteraction.banUser(authorPhoneNumber, convoId, true);
+  }, [authorPhoneNumber, convoId]);
+
   const onUnban = useCallback(() => {
     MessageInteraction.unbanUser(authorPhoneNumber, convoId);
   }, [authorPhoneNumber, convoId]);
@@ -165,6 +169,7 @@ export const MessageContextMenu = (props: PropsForMessageContextMenu) => {
         </>
       ) : null}
       {weAreAdmin && isPublic ? <Item onClick={onBan}>{window.i18n('banUser')}</Item> : null}
+      {weAreAdmin && isPublic ? <Item onClick={onBanAndDeleteAll}>{window.i18n('banUserAndDeleteAll')}</Item> : null}
       {weAreAdmin && isOpenGroupV2 ? (
         <Item onClick={onUnban}>{window.i18n('unbanUser')}</Item>
       ) : null}

--- a/ts/components/conversation/MessageContextMenu.tsx
+++ b/ts/components/conversation/MessageContextMenu.tsx
@@ -169,7 +169,9 @@ export const MessageContextMenu = (props: PropsForMessageContextMenu) => {
         </>
       ) : null}
       {weAreAdmin && isPublic ? <Item onClick={onBan}>{window.i18n('banUser')}</Item> : null}
-      {weAreAdmin && isPublic ? <Item onClick={onBanAndDeleteAll}>{window.i18n('banUserAndDeleteAll')}</Item> : null}
+      {weAreAdmin && isPublic ? (
+        <Item onClick={onBanAndDeleteAll}>{window.i18n('banUserAndDeleteAll')}</Item>
+      ) : null}
       {weAreAdmin && isOpenGroupV2 ? (
         <Item onClick={onUnban}>{window.i18n('unbanUser')}</Item>
       ) : null}

--- a/ts/interactions/messageInteractions.ts
+++ b/ts/interactions/messageInteractions.ts
@@ -10,7 +10,11 @@ import { ToastUtils } from '../session/utils';
 
 import { updateConfirmModal } from '../state/ducks/modalDialog';
 
-export function banUser(userToBan: string, conversationId: string, deleteAllMessages: boolean = false) {
+export function banUser(
+  userToBan: string,
+  conversationId: string,
+  deleteAllMessages: boolean = false
+) {
   let pubKeyToBan: PubKey;
   try {
     pubKeyToBan = PubKey.cast(userToBan);
@@ -24,8 +28,10 @@ export function banUser(userToBan: string, conversationId: string, deleteAllMess
     window.inboxStore?.dispatch(updateConfirmModal(null));
   };
 
-  const title = (deleteAllMessages) ? window.i18n('banUserAndDeleteAll') : window.i18n('banUser');
-  const message = (deleteAllMessages) ? window.i18n('banUserAndDeleteAllConfirm') : window.i18n('banUserConfirm');
+  const title = deleteAllMessages ? window.i18n('banUserAndDeleteAll') : window.i18n('banUser');
+  const message = deleteAllMessages
+    ? window.i18n('banUserAndDeleteAllConfirm')
+    : window.i18n('banUserConfirm');
 
   const confirmationModalProps = {
     title: title,
@@ -43,7 +49,11 @@ export function banUser(userToBan: string, conversationId: string, deleteAllMess
         if (!roomInfos) {
           window.log.warn('banUser room not found');
         } else {
-          success = await ApiV2.banUser(pubKeyToBan, _.pick(roomInfos, 'serverUrl', 'roomId'), deleteAllMessages);
+          success = await ApiV2.banUser(
+            pubKeyToBan,
+            _.pick(roomInfos, 'serverUrl', 'roomId'),
+            deleteAllMessages
+          );
         }
       } else {
         throw new Error('V1 opengroup are not supported');

--- a/ts/interactions/messageInteractions.ts
+++ b/ts/interactions/messageInteractions.ts
@@ -34,8 +34,8 @@ export function banUser(
     : window.i18n('banUserConfirm');
 
   const confirmationModalProps = {
-    title: title,
-    message: message,
+    title,
+    message,
     onClickClose,
     onClickOk: async () => {
       const conversation = getConversationController().get(conversationId);

--- a/ts/interactions/messageInteractions.ts
+++ b/ts/interactions/messageInteractions.ts
@@ -10,7 +10,7 @@ import { ToastUtils } from '../session/utils';
 
 import { updateConfirmModal } from '../state/ducks/modalDialog';
 
-export function banUser(userToBan: string, conversationId: string) {
+export function banUser(userToBan: string, conversationId: string, deleteAllMessages: boolean = false) {
   let pubKeyToBan: PubKey;
   try {
     pubKeyToBan = PubKey.cast(userToBan);
@@ -24,9 +24,12 @@ export function banUser(userToBan: string, conversationId: string) {
     window.inboxStore?.dispatch(updateConfirmModal(null));
   };
 
+  const title = (deleteAllMessages) ? window.i18n('banUserAndDeleteAll') : window.i18n('banUser');
+  const message = (deleteAllMessages) ? window.i18n('banUserAndDeleteAllConfirm') : window.i18n('banUserConfirm');
+
   const confirmationModalProps = {
-    title: window.i18n('banUser'),
-    message: window.i18n('banUserConfirm'),
+    title: title,
+    message: message,
     onClickClose,
     onClickOk: async () => {
       const conversation = getConversationController().get(conversationId);
@@ -40,7 +43,7 @@ export function banUser(userToBan: string, conversationId: string) {
         if (!roomInfos) {
           window.log.warn('banUser room not found');
         } else {
-          success = await ApiV2.banUser(pubKeyToBan, _.pick(roomInfos, 'serverUrl', 'roomId'));
+          success = await ApiV2.banUser(pubKeyToBan, _.pick(roomInfos, 'serverUrl', 'roomId'), deleteAllMessages);
         }
       } else {
         throw new Error('V1 opengroup are not supported');

--- a/ts/opengroup/opengroupV2/OpenGroupAPIV2.ts
+++ b/ts/opengroup/opengroupV2/OpenGroupAPIV2.ts
@@ -268,14 +268,14 @@ export const banUser = async (
   deleteAllMessages: boolean
 ): Promise<boolean> => {
   const queryParams = { public_key: userToBan.key };
-  const endPoint = deleteAllMessages ? 'ban_and_delete_all' : 'block_list';
+  const endpoint = deleteAllMessages ? 'ban_and_delete_all' : 'block_list';
   const request: OpenGroupV2Request = {
     method: 'POST',
     room: roomInfos.roomId,
     server: roomInfos.serverUrl,
     isAuthRequired: true,
     queryParams,
-    endpoint: endPoint,
+    endpoint,
   };
   const banResult = await exports.sendApiV2Request(request);
   const isOk = parseStatusCodeFromOnionRequest(banResult) === 200;

--- a/ts/opengroup/opengroupV2/OpenGroupAPIV2.ts
+++ b/ts/opengroup/opengroupV2/OpenGroupAPIV2.ts
@@ -268,7 +268,7 @@ export const banUser = async (
   deleteAllMessages: boolean
 ): Promise<boolean> => {
   const queryParams = { public_key: userToBan.key };
-  const endPoint = (deleteAllMessages) ? 'ban_and_delete_all' : 'block_list';
+  const endPoint = deleteAllMessages ? 'ban_and_delete_all' : 'block_list';
   const request: OpenGroupV2Request = {
     method: 'POST',
     room: roomInfos.roomId,

--- a/ts/opengroup/opengroupV2/OpenGroupAPIV2.ts
+++ b/ts/opengroup/opengroupV2/OpenGroupAPIV2.ts
@@ -264,16 +264,18 @@ export const postMessage = async (
 
 export const banUser = async (
   userToBan: PubKey,
-  roomInfos: OpenGroupRequestCommonType
+  roomInfos: OpenGroupRequestCommonType,
+  deleteAllMessages: boolean
 ): Promise<boolean> => {
   const queryParams = { public_key: userToBan.key };
+  const endPoint = (deleteAllMessages) ? 'ban_and_delete_all' : 'block_list';
   const request: OpenGroupV2Request = {
     method: 'POST',
     room: roomInfos.roomId,
     server: roomInfos.serverUrl,
     isAuthRequired: true,
     queryParams,
-    endpoint: 'block_list',
+    endpoint: endPoint,
   };
   const banResult = await exports.sendApiV2Request(request);
   const isOk = parseStatusCodeFromOnionRequest(banResult) === 200;


### PR DESCRIPTION
Moderators in public groups can now ban an user and delete all his messages in a single action