### PR TITLE
Display the service node's IP address after its country.

### DIFF
--- a/ts/components/dialog/OnionStatusPathDialog.tsx
+++ b/ts/components/dialog/OnionStatusPathDialog.tsx
@@ -69,7 +69,7 @@ const OnionPathModalInner = () => {
             {nodes.map((snode: Snode | any, index: number) => {
               let labelText = snode.label
                 ? snode.label
-                : countryLookup.byIso(ip2country(snode.ip))?.country;
+                : `${countryLookup.byIso(ip2country(snode.ip))?.country} [${snode.ip}]`;
               if (!labelText) {
                 labelText = window.i18n('unknownCountry');
               }


### PR DESCRIPTION
### First time contributor checklist:

* [x] I have read the [README](https://github.com/loki-project/loki-messenger/blob/master/README.md) and [Contributor Guidelines](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md)

### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

This change adds each service node's IP address to the onion path window. I personally find this information useful to check the networks of the nodes I am being routed through, and I think other users will enjoy having the extra information, too.

I have tested that the change works as described.
