### PR TITLE
Removing at regex test preventing some urls from rendering as links.

### DIFF
--- a/ts/components/conversation/Linkify.tsx
+++ b/ts/components/conversation/Linkify.tsx
@@ -17,7 +17,6 @@ interface Props {
 }
 
 const SUPPORTED_PROTOCOLS = /^(http|https):/i;
-const HAS_AT = /@/;
 
 export class Linkify extends React.Component<Props> {
   public static defaultProps: Partial<Props> = {
@@ -49,7 +48,8 @@ export class Linkify extends React.Component<Props> {
       }
 
       const { url, text: originalText } = match;
-      if (SUPPORTED_PROTOCOLS.test(url) && !isLinkSneaky(url) && !HAS_AT.test(url)) {
+      const isLink = SUPPORTED_PROTOCOLS.test(url) && !isLinkSneaky(url);
+      if (isLink) {
         results.push(
           <a key={count++} href={url} onClick={this.handleClick}>
             {originalText}


### PR DESCRIPTION
* Messages containing URLs with @ symbols are now clickable links.