### PR TITLE
Marking conversation as read if received a sync message from same use…

### DIFF
--- a/ts/receiver/queuedJob.ts
+++ b/ts/receiver/queuedJob.ts
@@ -227,7 +227,7 @@ function updateReadStatus(message: MessageModel, conversation: ConversationModel
   }
 }
 
-function handleSyncedReceipts(message: MessageModel, conversation: ConversationModel) {
+async function handleSyncedReceipts(message: MessageModel, conversation: ConversationModel) {
   const readReceipts = window.Whisper.ReadReceipts.forMessage(conversation, message);
   if (readReceipts.length) {
     const readBy = readReceipts.map((receipt: any) => receipt.get('reader'));
@@ -249,7 +249,7 @@ function handleSyncedReceipts(message: MessageModel, conversation: ConversationM
   // If the newly received message is from us, we assume that we've seen the messages up until that point
   const sentTimestamp = message.get('sent_at');
   if (sentTimestamp) {
-    conversation.markRead(sentTimestamp);
+    await conversation.markRead(sentTimestamp);
   }
 }
 
@@ -318,7 +318,7 @@ async function handleRegularMessage(
   }
 
   if (type === 'outgoing') {
-    handleSyncedReceipts(message, conversation);
+    await handleSyncedReceipts(message, conversation);
   }
 
   const conversationActiveAt = conversation.get('active_at');


### PR DESCRIPTION
Considers a conversation as read for a user (A) if receiving a new message in that conversation from that same user (A). 