### PR TITLE
Trim whitespace from open group URLs entered by user.

### DIFF
--- a/ts/opengroup/opengroupV2/JoinOpenGroupV2.ts
+++ b/ts/opengroup/opengroupV2/JoinOpenGroupV2.ts
@@ -18,7 +18,7 @@ import { getOpenGroupManager } from './OpenGroupManagerV2';
 // 143.198.213.255:80/main?public_key=658d29b91892a2389505596b135e76a53db6e11d613a51dbd3d0816adffb231c
 
 export function parseOpenGroupV2(urlWithPubkey: string): OpenGroupV2Room | undefined {
-  const lowerCased = urlWithPubkey.toLowerCase();
+  const lowerCased = urlWithPubkey.trim().toLowerCase();
   try {
     if (!openGroupV2CompleteURLRegex.test(lowerCased)) {
       throw new Error('regex fail');


### PR DESCRIPTION
### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

Currently, leading and/or trailing whitespace can be entered into the Open Group URL dialogue and is interpreted as part of the URL, causing the joining of the group to fail.

This patch trims whitespace from the URL after entry.