### PR TITLE
Make the [Home] and [End] keys scroll the conversation.

### DIFF
--- a/ts/components/session/conversation/SessionMessagesList.tsx
+++ b/ts/components/session/conversation/SessionMessagesList.tsx
@@ -23,6 +23,8 @@ export const SessionMessagesList = (props: {
   scrollToQuoteMessage: (options: QuoteClickOptions) => Promise<void>;
   onPageUpPressed: () => void;
   onPageDownPressed: () => void;
+  onHomePressed: () => void;
+  onEndPressed: () => void;
 }) => {
   const messagesProps = useSelector(getSortedMessagesTypesOfSelectedConversation);
 
@@ -32,6 +34,14 @@ export const SessionMessagesList = (props: {
 
   useKey('PageDown', () => {
     props.onPageDownPressed();
+  });
+
+  useKey('Home', () => {
+    props.onHomePressed();
+  });
+
+  useKey('End', () => {
+    props.onEndPressed();
   });
 
   return (

--- a/ts/components/session/conversation/SessionMessagesListContainer.tsx
+++ b/ts/components/session/conversation/SessionMessagesListContainer.tsx
@@ -151,6 +151,8 @@ class SessionMessagesListContainerInner extends React.Component<Props> {
           scrollToQuoteMessage={this.scrollToQuoteMessage}
           onPageDownPressed={this.scrollPgDown}
           onPageUpPressed={this.scrollPgUp}
+          onHomePressed={this.scrollTop}
+          onEndPressed={this.scrollEnd}
         />
 
         <SessionScrollButton onClick={this.scrollToBottom} key="scroll-down-button" />
@@ -265,6 +267,24 @@ class SessionMessagesListContainerInner extends React.Component<Props> {
       top: Math.floor(+messageContainer.clientHeight * 2) / 3,
       behavior: 'smooth',
     });
+  }
+
+  private scrollTop() {
+    const messageContainer = this.props.messageContainerRef.current;
+    if (!messageContainer) {
+      return;
+    }
+
+    messageContainer.scrollTo(0, -messageContainer.scrollHeight);
+  }
+
+  private scrollEnd() {
+    const messageContainer = this.props.messageContainerRef.current;
+    if (!messageContainer) {
+      return;
+    }
+
+    messageContainer.scrollTo(0, 0);
   }
 
   private async scrollToQuoteMessage(options: QuoteClickOptions) {


### PR DESCRIPTION
[End] will scroll to the end of the current conversation, because the
latest message is always available.

[Home], however, will scroll only to the top of the currently loaded
messages, triggering earlier messages to load. Multiple presses of
[Home] are therefore required to get to the start of the conversation.

### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

I wanted to implement [Home] such that it would continuously reload earlier messages until it reached the start of the conversation, but I couldn't get it to work. This is therefore a compromise, sending the user to the earliest message currently available and triggering the loading of even earlier messages, if available.