### PR TITLE
Open group regex fixes

### DIFF
--- a/ts/components/session/LeftPaneMessageSection.tsx
+++ b/ts/components/session/LeftPaneMessageSection.tsx
@@ -461,6 +461,7 @@ export class LeftPaneMessageSection extends React.Component<Props, State> {
         this.handleToggleOverlay(undefined);
       }
     } else {
+      ToastUtils.pushToastError('invalidOpenGroupUrl', window.i18n('invalidOpenGroupUrl'));
       window.log.warn('Invalid opengroupv2 url');
     }
   }

--- a/ts/opengroup/utils/OpenGroupUtils.ts
+++ b/ts/opengroup/utils/OpenGroupUtils.ts
@@ -1,21 +1,20 @@
 import { OpenGroupV2Room } from '../../data/opengroups';
 import { OpenGroupRequestCommonType } from '../opengroupV2/ApiUtil';
 
-const protocolRegex = new RegExp('(https?://)?');
+const protocolRegex = new RegExp('https?://');
 
 const dot = '\\.';
 const qMark = '\\?';
-const hostnameRegex = new RegExp(
-  `(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])${dot})*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])`
-);
-const portRegex = '(:[0-9]+)?';
+const hostSegment = '[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?';
+const hostnameRegex = new RegExp(`(?:${hostSegment}${dot})+${hostSegment}`);
+const portRegex = ':[1-9][0-9]{0,4}';
 
-// roomIds allows between 2 and 64 of '0-9' or 'a-z' or '_' chars
-export const roomIdV2Regex = '[0-9a-z_]{2,64}';
-export const publicKeyRegex = '[0-9a-z]{64}';
+// roomIds allow up to 64 ascii numbers, letters, '_', or '-' chars
+export const roomIdV2Regex = '[0-9a-zA-Z_-]{1,64}';
+export const publicKeyRegex = '[0-9a-fA-F]{64}';
 export const publicKeyParam = 'public_key=';
 export const openGroupV2ServerUrlRegex = new RegExp(
-  `${protocolRegex.source}${hostnameRegex.source}${portRegex}`
+  `(?:${protocolRegex.source})?${hostnameRegex.source}(?:${portRegex})?`
 );
 
 /**
@@ -25,8 +24,7 @@ export const openGroupV2ServerUrlRegex = new RegExp(
  * see https://stackoverflow.com/a/9275499/1680951
  */
 export const openGroupV2CompleteURLRegex = new RegExp(
-  `${openGroupV2ServerUrlRegex.source}\/${roomIdV2Regex}${qMark}${publicKeyParam}${publicKeyRegex}`,
-  'm'
+  `^${openGroupV2ServerUrlRegex.source}\/${roomIdV2Regex}${qMark}${publicKeyParam}${publicKeyRegex}$`
 );
 
 /**


### PR DESCRIPTION
Currently the desktop Session high-level GUI silently refuses (i.e. just doesn't do anything, without feedback) some URLs it should allow, and accepts some invalid URLs it should refuse.

This updates the regex to fix the acceptance criteria, and adds an displayed error message when an invalid URL is entered.

---
Details:
- Add an error popup when the URL is rejected for being invalid.
- Capital letters in room tokens were not being accepted (it eventually gets lower-cased internally, which works fine, but that happens *after* the URL is tested for acceptability).
- `-` in room was not being allowed (it is and always has been on SOGS, session-android, and session-ios).
- one-letter rooms weren't being allowed (but are valid).
- complete URL regex wasn't anchored so something like `garbagehttps://example.com/room?public_key=<64hex>moregarbage` was being accepted in the GUI input (it fails later when other code tries to parse it as a URL).
- removed `m` modifier from open group regex: without anchors it wasn't doing anything anyway, but *with* anchors it would still allow leading/trailing garbage if delineated by newlines.
- public key regex was accepting g-z letters, and not accepting A-F.
- various regex cleanups:
  - use non-capture groups (?:...) rather than capturing groups (...)
  - avoid repetition in host segment matching
- tightened up host pattern matching a bit:
  - DNS host segments have a max length of 63
  - Limit port max length to 5, and disallow starting with 0