### PR TITLE
Make per conversation unread message count stand out better.

### DIFF
--- a/stylesheets/_session_left_pane.scss
+++ b/stylesheets/_session_left_pane.scss
@@ -41,8 +41,8 @@ $session-compose-margin: 20px;
     }
 
     &__unread-count {
-      color: var(--color-text);
-      background: var(--color-clickable-hovered);
+      color: black;
+      background: var(--color-accent);
 
       position: static !important;
       font-weight: 700 !important;


### PR DESCRIPTION
### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

This fixes oxen-io/session-desktop-temp#458.

### Description

This alters the background of the per conversation unread message count from dark grey to Session green, the same colour used to highlight conversations (with an `@` symbol) in which the user has received a mention.

Not only does it make sense to highlight both types with the same colour, since both are indicators of unread messages, but the previous dark grey background of the unread message count was often barely noticeable against the dark grey of dark mode.

With this change, the digits of the unread count will be displayed in black characters, regardless of light or dark mode, in order to ensure legibility in both environments.

![image](https://user-images.githubusercontent.com/749942/153107127-34c82f90-9d8a-437d-9a12-8a08a64f1a72.png)

I have submitted a similar change to the Android client:

https://github.com/oxen-io/session-android/pull/840