### PR TITLE
Use up to two scaled placeholder characters for users with no avatar.

### DIFF
--- a/ts/components/avatar/AvatarPlaceHolder/AvatarPlaceHolder.tsx
+++ b/ts/components/avatar/AvatarPlaceHolder/AvatarPlaceHolder.tsx
@@ -97,8 +97,12 @@ export const AvatarPlaceHolder = (props: Props) => {
     );
   }
 
-  const initial = getInitials(name)?.toLocaleUpperCase() || '0';
-  const fontSize = diameter * 0.5;
+  let initials = getInitials(name)?.toLocaleUpperCase() || '0';
+  if (name.indexOf(' ') === -1) {
+    initials = name.substr(0, 2);
+  }
+
+  const fontSize = diameter * (1 / (initials.length + 1));
 
   const bgColorIndex = hash % avatarPlaceholderColors.length;
 
@@ -126,7 +130,7 @@ export const AvatarPlaceHolder = (props: Props) => {
           strokeWidth={1}
           alignmentBaseline="central"
         >
-          {initial}
+          {initials}
         </text>
       </g>
     </svg>

--- a/ts/util/getInitials.ts
+++ b/ts/util/getInitials.ts
@@ -7,5 +7,9 @@ export function getInitials(name?: string): string | undefined {
     return name[2];
   }
 
-  return name[0];
+  const initials = name.split(' ').slice(0, 2).map(n => {
+    return n[0];
+  })
+
+  return initials.join('');
 }


### PR DESCRIPTION
Use up to two scaled initials as a placeholder for users with no avatar.
    
If the user's name consists of just a single word, then use up to two letters from that word as the placeholder.

This provides better differentiation of users than the current practice of using just a single letter for everyone.

### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

There's enough space in the avatar placeholder circle to place up to three scaled initials, which provides better user differentiation than a single letter.

@KeeJef considered the use of three initials excessive, so this has been reduced to a maximum of two. The screenshot below illustrates one-, two- and three-letter placeholder values.

Tested on Linux and Windows.

<img width="266" alt="image" src="https://user-images.githubusercontent.com/749942/155637898-a15053f4-53a6-449f-ad04-95155f52790a.png">
