### PR TITLE
Allow user names up to 26 characters long, in line with Android.

### DIFF
--- a/ts/components/registration/RegistrationStages.tsx
+++ b/ts/components/registration/RegistrationStages.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../util/accountManager';
 import { fromHex } from '../../session/utils/String';
 
-export const MAX_USERNAME_LENGTH = 20;
+export const MAX_USERNAME_LENGTH = 26;
 // tslint:disable: use-simple-attributes
 
 export async function resetRegistration() {


### PR DESCRIPTION
See https://github.com/oxen-io/session-android/blob/master/libsession/src/main/java/org/session/libsession/utilities/SSKEnvironment.kt#L29

### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

Desktop is inconsistent with Android. It allows user names of up to 20 characters, whereas Android allows up to 26 characters.

This brings desktop in line with Android.

My binary OCD would prefer 32. I mean, why 26?

Fixes #2206.

Tested on Linux and Windows.