### PR TITLE
Skip placeholder chars that are not in any alphabet or number system.

### DIFF
--- a/ts/util/getInitials.ts
+++ b/ts/util/getInitials.ts
@@ -8,11 +8,14 @@ export function getInitials(name?: string): string {
     return upperAndShorten(name[2]);
   }
 
-  if (name.indexOf(' ') === -1) {
-    // there is no space, just return the first 2 chars of the name
+  if (name.split(/[-\s]/).length === 1) {
+    // there is one word, so just return the first 2 alphanumeric chars of the name
 
     if (name.length > 1) {
-      return upperAndShorten(name.slice(0, 2));
+      const alphanum = name.match(/[\p{L}\p{N}]+/u);
+      if (alphanum) {
+	return upperAndShorten(alphanum[0].slice(0, 2));
+      }
     }
     return upperAndShorten(name[0]);
   }
@@ -20,11 +23,12 @@ export function getInitials(name?: string): string {
   // name has a space, just extract the first char of each words
   return upperAndShorten(
     name
-      .split(' ')
+      .split(/[-\s]/)
       .slice(0, 2)
-      .map(n => {
-        return n[0];
-      })
+      .map(n =>
+	// Allow a letter or a digit from any alphabet.
+        n.match(/^[\p{L}\p{N}]/u)
+      )
       .join('')
   );
 }


### PR DESCRIPTION
### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

Now we have multi-character placeholders, decorative characters employed by the user are making it into the placeholder.

This patch ensures that only letters from known alphabets and digits from known number systems are used in the placeholder.

Additionally, we split names on hyphens as well as spaces, so that `Foo-Bar`, for example, becomes `FB` rather than just `F`.