### PR TITLE
Clarify that the search box can now also find individual messages.

### DIFF
--- a/_locales/bg/messages.json
+++ b/_locales/bg/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "Новый Диалог",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Введите Session ID",
   "enterSessionIDOfRecipient": "Введите Session ID получателя",
   "usersCanShareTheir...": "Пользователи могут поделиться своим Session ID, зайдя в настройки своей учетной записи и нажав «Отправить Session ID», или поделившись своим QR-кодом.",

--- a/_locales/ca/messages.json
+++ b/_locales/ca/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Comenceu la vostra sessió.",
   "welcomeToYourSession": "Benvingut a Session",
   "newSession": "Nova sessió",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Introdueix la teva ID de Session",
   "enterSessionIDOfRecipient": "Introduïu l'identificador de Session o el nom ONS del destinatari",
   "usersCanShareTheir...": "Els usuaris poden compartir el seu identificador de Session accedint a la configuració del compte i tocant \"Comparteix l'identificador de sessió\" o compartint el seu codi QR.",

--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/da/messages.json
+++ b/_locales/da/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begynd din Session.",
   "welcomeToYourSession": "Velkommen til Session",
   "newSession": "Ny Session",
-  "searchFor...": "Søg efter samtaler eller kontakter",
+  "searchFor...": "Søg efter beskeder eller samtaler",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Beginnen Sie Ihre Session.",
   "welcomeToYourSession": "Willkommen bei Session",
   "newSession": "Neue Session",
-  "searchFor...": "Nach Unterhaltungen oder Kontakten suchen",
+  "searchFor...": "Nach Nachrichten oder Unterhaltungen suchen",
   "enterSessionID": "Session ID eingeben",
   "enterSessionIDOfRecipient": "Geben Sie eine Session ID ein.",
   "usersCanShareTheir...": "Benutzer können ihre Session ID freigeben, indem sie in ihren Einstellungen auf \"Session ID freigeben\" tippen oder ihren QR-Code freigeben.",

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -320,7 +320,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/eo/messages.json
+++ b/_locales/eo/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Comienza tu Session.",
   "welcomeToYourSession": "Bienvenido a tu Session",
   "newSession": "Nueva Session",
-  "searchFor...": "Buscar conversaciones o contactos",
+  "searchFor...": "Buscar mensajes o conversaciones",
   "enterSessionID": "Session ID",
   "enterSessionIDOfRecipient": "Ingresa la ID de Session del destinatario",
   "usersCanShareTheir...": "Los usuarios pueden compartir su ID de Session yendo a los ajustes de su cuenta y pulsando en Compartir ID de Session o compartiendo su código QR",

--- a/_locales/es_419/messages.json
+++ b/_locales/es_419/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/et/messages.json
+++ b/_locales/et/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/fil/messages.json
+++ b/_locales/fil/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Commencez votre Session.",
   "welcomeToYourSession": "Bienvenue sur Session",
   "newSession": "Nouvelle Session",
-  "searchFor...": "Rechercher des conversations ou des contacts",
+  "searchFor...": "Rechercher des messages ou des conversations",
   "enterSessionID": "Saisir un Session ID",
   "enterSessionIDOfRecipient": "Saisissez le Session ID du destinataire",
   "usersCanShareTheir...": "Les utilisateurs peuvent partager leur Session ID depuis les paramètres du compte ou en utilisant le code QR.",

--- a/_locales/he/messages.json
+++ b/_locales/he/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/hr/messages.json
+++ b/_locales/hr/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Üdvözöl a Session",
   "newSession": "Új beszélgetés",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Session azonosító megadása",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "Session baru",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Masuk ke Session ID",
   "enterSessionIDOfRecipient": "Masukkan Session ID penerima",
   "usersCanShareTheir...": "Pengguna bisa membagikan Session ID miliknya dengan masuk ke pengaturan akun dan mengetuk \"Bagikan Session ID\" atau dengan membagikan kode QR mereka",

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Inizia la tua Session.",
   "welcomeToYourSession": "Benvenuto su Session",
   "newSession": "Nuova sessione",
-  "searchFor...": "Ricerca conversazioni o contatti",
+  "searchFor...": "Ricerca messaggi o conversazioni",
   "enterSessionID": "Inserisci la Sessione ID",
   "enterSessionIDOfRecipient": "Inserisci la Sessione ID del destinatario",
   "usersCanShareTheir...": "Gli utenti possono condividere la propria Sessione ID accedendo alle impostazioni del proprio account e toccando Condividi la Sessione ID o condividendo il proprio codice QR.",

--- a/_locales/ka/messages.json
+++ b/_locales/ka/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/km/messages.json
+++ b/_locales/km/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/kn/messages.json
+++ b/_locales/kn/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/lt/messages.json
+++ b/_locales/lt/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/mk/messages.json
+++ b/_locales/mk/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/nb/messages.json
+++ b/_locales/nb/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin je sessie.",
   "welcomeToYourSession": "Welkom bij Session",
   "newSession": "Nieuwe sessie",
-  "searchFor...": "Zoeken naar gesprekken of contacten",
+  "searchFor...": "Zoeken naar berichten of gesprekken",
   "enterSessionID": "Uw Session-ID",
   "enterSessionIDOfRecipient": "Voer de Session ID van de ontvanger in",
   "usersCanShareTheir...": "Gebruikers kunnen hun Session-ID delen door naar hun accountinstellingen te gaan en op \"Deel Session-ID\" te tikken, of door hun QR-code te delen.",

--- a/_locales/no/messages.json
+++ b/_locales/no/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Start økten din.",
   "welcomeToYourSession": "Velkommen til økten din",
   "newSession": "Ny økt",
-  "searchFor...": "Søk etter samtaler eller kontakter",
+  "searchFor...": "Søk etter beskjeder eller samtaler",
   "enterSessionID": "Skriv inn Session-ID",
   "enterSessionIDOfRecipient": "Skriv inn mottakerens Session-ID eller ONS-navn",
   "usersCanShareTheir...": "Brukere kan dele sin Session-ID ved å gå inn i sine kontoinnstillinger og trykke på \"Del Session-ID\", eller ved å dele sin QR-kode.",

--- a/_locales/pa/messages.json
+++ b/_locales/pa/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Inicie seu Session.",
   "welcomeToYourSession": "Bem-vindo(a) ao seu Session",
   "newSession": "Nova Sessão",
-  "searchFor...": "Procurar por conversas ou contatos",
+  "searchFor...": "Procurar por mensagens ou conversas",
   "enterSessionID": "Digite o ID Session",
   "enterSessionIDOfRecipient": "Digite o ID Session do destinatário",
   "usersCanShareTheir...": "Os usuários podem compartilhar seus IDs Session acessando as configurações da conta e tocando em Compartilhar ID Session, ou compartilhando o código QR.",

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/ro/messages.json
+++ b/_locales/ro/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Începe sesiunea.",
   "welcomeToYourSession": "Bine ai venit pe Session",
   "newSession": "Sesiune nouă",
-  "searchFor...": "Căutați conversații sau contacte",
+  "searchFor...": "Căutați mesaje sau conversații",
   "enterSessionID": "Introduceți ID-ul Session",
   "enterSessionIDOfRecipient": "Introduceți ID-ul Session sau numele ONS al destinatarului",
   "usersCanShareTheir...": "Utilizatorii pot partaja ID-ul Session intrând în setările lor de cont și apăsând \"Partajează ID-ul Session\" sau partajând codul lor QR.",

--- a/_locales/sl/messages.json
+++ b/_locales/sl/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/sq/messages.json
+++ b/_locales/sq/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Börja din Session.",
   "welcomeToYourSession": "Välkommen till Session",
   "newSession": "Ny Session",
-  "searchFor...": "Sök efter konversationer eller kontakter",
+  "searchFor...": "Sök efter meddelanden eller konversationer",
   "enterSessionID": "Ange Session-ID",
   "enterSessionIDOfRecipient": "Ange Session-ID eller ONS-namnet på mottagaren",
   "usersCanShareTheir...": "Användare kan dela sitt Session-ID genom att gå in på Kontoinställningar och trycka på \"Dela Session-ID\" eller genom att dela sin QR-kod.",

--- a/_locales/ta/messages.json
+++ b/_locales/ta/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/th/messages.json
+++ b/_locales/th/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/uz/messages.json
+++ b/_locales/uz/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "Session mới",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Nhập Session ID",
   "enterSessionIDOfRecipient": "Nhập Session ID của người nhận",
   "usersCanShareTheir...": "Người dùng có thể chia sẻ Session ID của mình bằng cách tới mục cài đặt tài khoản và chạm vào “Chia sẻ Session ID”, hoặc bằng cách chia sẻ mã QR của họ.",

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -354,7 +354,7 @@
   "beginYourSession": "Begin your Session.",
   "welcomeToYourSession": "Welcome to your Session",
   "newSession": "New Session",
-  "searchFor...": "Search for conversations or contacts",
+  "searchFor...": "Search for messages or conversations",
   "enterSessionID": "Enter Session ID",
   "enterSessionIDOfRecipient": "Enter Session ID or ONS name of recipient",
   "usersCanShareTheir...": "Users can share their Session ID by going into their account settings and tapping \"Share Session ID\", or by sharing their QR code.",


### PR DESCRIPTION
I have encountered several cases now of users not realising that search
can be used to find text in messages.

### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

The current search box hint text doesn't make clear that one can also search message content.

This patch includes translations for the languages I understand well enough to make the change myself. Many other languages did not yet have even a translation for the old string, so in those cases I have modified the English-language message.