### PR TITLE
Reduce untagged message opacity during message selection.

### DIFF
--- a/stylesheets/_session_conversation.scss
+++ b/stylesheets/_session_conversation.scss
@@ -91,7 +91,7 @@
   .selection-mode {
     .messages-container > *:not(.message-selected) {
       animation: toShadow $session-transition-duration;
-      opacity: 0.25;
+      opacity: 0.40;
     }
   }
 }


### PR DESCRIPTION
This improves legibility for moderators when reading through a group and
tagging messages for deletion.

### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

Once the user tags a message for deletion, it becomes hard to read the other messages as one scrolls through the group, yet this is the most efficient workflow for a moderator.

This patch renders unselected messages less dark and therefore more legible,