### PR TITLE
Make messages with images use more of the display width.

### DIFF
--- a/ts/components/conversation/message/message-content/MessageContent.tsx
+++ b/ts/components/conversation/message/message-content/MessageContent.tsx
@@ -199,7 +199,7 @@ export const MessageContent = (props: Props) => {
         flashGreen && 'flash-green-once'
       )}
       style={{
-        width: isShowingImage ? width : undefined,
+        minWidth: isShowingImage ? width : undefined,
       }}
       role="button"
       onClick={onClickOnMessageInnerContainer}

--- a/ts/components/conversation/message/message-content/MessageContentWithStatus.tsx
+++ b/ts/components/conversation/message/message-content/MessageContentWithStatus.tsx
@@ -76,7 +76,7 @@ export const MessageContentWithStatuses = (props: Props) => {
       role="button"
       onClick={onClickOnMessageOuterContainer}
       onDoubleClickCapture={onDoubleClickReplyToMessage}
-      style={{ width: hasAttachments && isTrustedForAttachmentDownload ? 'min-content' : 'auto' }}
+      style={{ width: hasAttachments && isTrustedForAttachmentDownload ? 'auto' : 'auto' }}
       data-testid={dataTestId}
     >
       <MessageStatus


### PR DESCRIPTION
### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

Messages with an attachment use only a small fraction of the screen width to display the text of the message.

This patch ensures that more of the available width is utilised. It's still a bit on the ugly side, but screen utilisation is definitely improved. This makes for a much more pleasant reading experience.

Before:

<img width="172" alt="image" src="https://user-images.githubusercontent.com/749942/160206273-cac37526-15f9-4909-9c1c-52449be84cd3.png">

After:

![image](https://user-images.githubusercontent.com/749942/160208621-48e86ebe-2c28-43b4-bbbb-b7270bab42ec.png)
