### PR TITLE
fixed emoji selector when searching non-alphanumeric characters e.g. emoticons

### DIFF
--- a/ts/components/conversation/composition/CompositionBox.tsx
+++ b/ts/components/conversation/composition/CompositionBox.tsx
@@ -423,7 +423,7 @@ class CompositionBoxInner extends React.Component<Props, State> {
     const { isKickedFromGroup, left, isPrivate, isBlocked } = this.props.selectedConversation;
     const messagePlaceHolder = makeMessagePlaceHolderText();
     const { typingEnabled } = this.props;
-    const neverMatchingRegex = /(\W)$/;
+    const neverMatchingRegex = /($a)/;
 
     return (
       <MentionsInput

--- a/ts/components/conversation/composition/CompositionBox.tsx
+++ b/ts/components/conversation/composition/CompositionBox.tsx
@@ -423,7 +423,7 @@ class CompositionBoxInner extends React.Component<Props, State> {
     const { isKickedFromGroup, left, isPrivate, isBlocked } = this.props.selectedConversation;
     const messagePlaceHolder = makeMessagePlaceHolderText();
     const { typingEnabled } = this.props;
-    const neverMatchingRegex = /($a)/;
+    const neverMatchingRegex = /(\W)$/;
 
     return (
       <MentionsInput

--- a/ts/components/conversation/composition/EmojiQuickResult.tsx
+++ b/ts/components/conversation/composition/EmojiQuickResult.tsx
@@ -28,16 +28,18 @@ export const searchEmojiForQuery = (query: string): Array<SuggestionDataItem> =>
   if (query.length === 0 || !emojiIndex) {
     return [];
   }
-  const results = emojiIndex.search(query);
+  const results1 = emojiIndex.search(":"+query) || [];
+  const results2 = emojiIndex.search(query) || [];
+  const results = [...new Set(results1.concat(results2))];
   if (!results || !results.length) {
     return [];
   }
   return results
     .map(o => {
-      const onlyBaseEmokji = o as BaseEmoji;
+      const onlyBaseEmoji = o as BaseEmoji;
       return {
-        id: onlyBaseEmokji.native,
-        display: onlyBaseEmokji.colons,
+        id: onlyBaseEmoji.native,
+        display: onlyBaseEmoji.colons,
       };
     })
     .slice(0, 8);

--- a/ts/components/conversation/composition/EmojiQuickResult.tsx
+++ b/ts/components/conversation/composition/EmojiQuickResult.tsx
@@ -28,7 +28,7 @@ export const searchEmojiForQuery = (query: string): Array<SuggestionDataItem> =>
   if (query.length === 0 || !emojiIndex) {
     return [];
   }
-  const results1 = emojiIndex.search(":"+query) || [];
+  const results1 = emojiIndex.search(`:${query}`) || [];
   const results2 = emojiIndex.search(query) || [];
   const results = [...new Set(results1.concat(results2))];
   if (!results || !results.length) {


### PR DESCRIPTION
### First time contributor checklist:

* [x] I have read the [README](https://github.com/loki-project/loki-messenger/blob/master/README.md) and [Contributor Guidelines](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md)

### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

Currently emoji selector panel is triggered by ':', this commit changes the behaviour to exclude non alphanumeric characters from triggering the emoji selector panel (e.g. ':)' which is a common case with unexpected behaviour)

### Testing

#### What kind of manual testing did you do?

- recreated the unexpected behaviour on session, compared to other messaging apps
- tested messages with and without other text in addition to the emoji trigger
- tested that the search function worked correctly (once the quick selector window was triggered)
- tested that confirming emoji selection worked as expected (e.g. does not also paste the search text after the emoji)
- tested each behaviour multiple times to ensure consistency

#### Did you write any new tests?

No

#### What operating systems did you test with?

MacOS Monterey 12.2.1 (21D62)
