### PR TITLE
Make configuration sync every 2 days, in line with the comment.

### DIFF
--- a/ts/session/utils/syncUtils.ts
+++ b/ts/session/utils/syncUtils.ts
@@ -46,7 +46,7 @@ export const syncConfigurationIfNeeded = async () => {
   const now = Date.now();
 
   // if the last sync was less than 2 days before, return early.
-  if (Math.abs(now - lastSyncedTimestamp) < DURATION.DAYS * 7) {
+  if (Math.abs(now - lastSyncedTimestamp) < DURATION.DAYS * 2) {
     return;
   }
 


### PR DESCRIPTION
This changed in  55253125428f1cc72d86f833b7ffca265e2feb84, way back in May 2021. It looks as if the comment wasn't updated in line with the change.

However, shouldn't a configuration sync occur more often than once a week? If so, this PR changes it back.

Alternatively, I can submit a PR to fix the comment.