### PR TITLE
When deleting multiple messages, inform the user of the number.

### DIFF
--- a/_locales/bg/messages.json
+++ b/_locales/bg/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Удалить сообщения",
   "deleted": "Deleted",

--- a/_locales/ca/messages.json
+++ b/_locales/ca/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "No teniu autorització per esborrar els missatges d'altres",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Suprimeix els missatges",
   "deleted": "Eliminat",

--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Smazat zprávy",
   "deleted": "Deleted",

--- a/_locales/da/messages.json
+++ b/_locales/da/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "Du har ikke tilladelse til at slette andres beskeder",
   "deleteJustForMe": "Slet - kun for mig",
   "deleteForEveryone": "Slet for alle",
-  "deleteMessagesQuestion": "Slet disse beskeder?",
+  "deleteMessagesQuestion": "Slet $count$ beskeder?",
   "deleteMessageQuestion": "Slet denne besked?",
   "deleteMessages": "Slet beskeder",
   "deleted": "Slettet",

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Διαγραφή Μηνυμάτων",
   "deleted": "Deleted",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -94,7 +94,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Delete Messages",
   "deleted": "Deleted",

--- a/_locales/eo/messages.json
+++ b/_locales/eo/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Forigi mesaĝojn",
   "deleted": "Deleted",

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "No tienes permiso de borrar mensajes de otros",
   "deleteJustForMe": "Eliminar solo para mí",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Eliminar mensajes",
   "deleted": "Eliminado",

--- a/_locales/es_419/messages.json
+++ b/_locales/es_419/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Delete Messages",
   "deleted": "Deleted",

--- a/_locales/et/messages.json
+++ b/_locales/et/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Kustuta sõnumid",
   "deleted": "Deleted",

--- a/_locales/fil/messages.json
+++ b/_locales/fil/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Delete Messages",
   "deleted": "Deleted",

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "Vous n'êtes pas autorisé à supprimer les messages des autres utilisateurs.",
   "deleteJustForMe": "Supprimer juste pour moi",
   "deleteForEveryone": "Supprimer pour tous",
-  "deleteMessagesQuestion": "Êtes-vous certains de vouloir supprimer les messages?",
+  "deleteMessagesQuestion": "Êtes-vous certains de vouloir supprimer les $count$ messages?",
   "deleteMessageQuestion": "Êtes-vous sûr de vouloir supprimer ce message?",
   "deleteMessages": "Supprimer les messages",
   "deleted": "Supprimé",

--- a/_locales/he/messages.json
+++ b/_locales/he/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "מחק הודעות",
   "deleted": "Deleted",

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "संदेश हटाएँ",
   "deleted": "हटा दिया गया",

--- a/_locales/hr/messages.json
+++ b/_locales/hr/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Izbriši poruku",
   "deleted": "Deleted",

--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "Nincs joga mások üzeneteit törölni",
   "deleteJustForMe": "Törlés csak nálam",
   "deleteForEveryone": "Törlés mindenkinél",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Törli ezt az üzenetet?",
   "deleteMessages": "Üzenetek törlése",
   "deleted": "Törölve",

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "Anda tidak diizinkan untuk menghapus pesan lainnya",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Hapus pesan",
   "deleted": "Terhapus",

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "Non hai il permesso di eliminare i messaggi degli altri",
   "deleteJustForMe": "Elimina solo per me",
   "deleteForEveryone": "Elimina per tutti",
-  "deleteMessagesQuestion": "Eliminare questi messaggi?",
+  "deleteMessagesQuestion": "Eliminare $count$ messaggi?",
   "deleteMessageQuestion": "Cancellare questo messaggio?",
   "deleteMessages": "Elimina messaggi",
   "deleted": "Eliminata",

--- a/_locales/ka/messages.json
+++ b/_locales/ka/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Delete Messages",
   "deleted": "Deleted",

--- a/_locales/km/messages.json
+++ b/_locales/km/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "លុបសារ",
   "deleted": "Deleted",

--- a/_locales/kn/messages.json
+++ b/_locales/kn/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Delete Messages",
   "deleted": "Deleted",

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "다른 사람의 메시지를 삭제할 수 있는 권한이 없습니다.",
   "deleteJustForMe": "자기 자신만 안 보이게 삭제",
   "deleteForEveryone": "모두에게서 삭제",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "이 메시지를 삭제하시겠습니까?",
   "deleteMessages": "Delete messages",
   "deleted": "삭제",

--- a/_locales/lt/messages.json
+++ b/_locales/lt/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Ištrinti žinutes",
   "deleted": "Deleted",

--- a/_locales/mk/messages.json
+++ b/_locales/mk/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Избриши пораки",
   "deleted": "Deleted",

--- a/_locales/nb/messages.json
+++ b/_locales/nb/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Delete Messages",
   "deleted": "Deleted",

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "Je hebt geen toestemming om andermans berichten te verwijderen",
   "deleteJustForMe": "Verwijder alleen voor mij",
   "deleteForEveryone": "Verwijder voor iedereen",
-  "deleteMessagesQuestion": "Verwijder die berichten?",
+  "deleteMessagesQuestion": "Verwijder $count$ berichten?",
   "deleteMessageQuestion": "Dit bericht verwijderen?",
   "deleteMessages": "Berichten wissen",
   "deleted": "Verwijderd",

--- a/_locales/no/messages.json
+++ b/_locales/no/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "Du har ikke tillatelse til å slette andres beskjeder",
   "deleteJustForMe": "Slett kun for meg",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Slett beskjeder",
   "deleted": "Slettet",

--- a/_locales/pa/messages.json
+++ b/_locales/pa/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Delete Messages",
   "deleted": "Deleted",

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "Você não tem permissão para excluír as mensagens de outros",
   "deleteJustForMe": "Excluir apenas para mim",
   "deleteForEveryone": "Excluir para todos",
-  "deleteMessagesQuestion": "Excluir mensagens?",
+  "deleteMessagesQuestion": "Excluir $count$ mensagens?",
   "deleteMessageQuestion": "Excluir esta mensagem?",
   "deleteMessages": "Apagar mensagens",
   "deleted": "Excluído",

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Eliminar mensagens",
   "deleted": "Deleted",

--- a/_locales/ro/messages.json
+++ b/_locales/ro/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "Nu aveţi permisiunea de a şterge mesajele altora",
   "deleteJustForMe": "Șterge doar pentru mine",
   "deleteForEveryone": "Șterge pentru toată lumea",
-  "deleteMessagesQuestion": "Ștergi acele mesaje?",
+  "deleteMessagesQuestion": "Ștergi acele $count$ mesaje?",
   "deleteMessageQuestion": "Ștergi acest mesaj?",
   "deleteMessages": "Șterge mesajele",
   "deleted": "Șters",

--- a/_locales/si/messages.json
+++ b/_locales/si/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Delete Messages",
   "deleted": "Deleted",

--- a/_locales/sq/messages.json
+++ b/_locales/sq/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Fshini mesazhe",
   "deleted": "Deleted",

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "Du har inte behörighet att ta bort andras meddelanden",
   "deleteJustForMe": "Radera bara för mig",
   "deleteForEveryone": "Radera för alla",
-  "deleteMessagesQuestion": "Radera dessa meddelanden?",
+  "deleteMessagesQuestion": "Radera $count$ meddelanden?",
   "deleteMessageQuestion": "Radera detta meddelande?",
   "deleteMessages": "Radera meddelanden",
   "deleted": "Raderat",

--- a/_locales/ta/messages.json
+++ b/_locales/ta/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "தகவலைகலை நீக்கு",
   "deleted": "நீக்கபடுல்லது",

--- a/_locales/th/messages.json
+++ b/_locales/th/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "ลบข้อความ",
   "deleted": "Deleted",

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "У вас немає дозволу на видалення повідомлень інших",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Видалити повідомлення",
   "deleted": "Видалено",

--- a/_locales/uz/messages.json
+++ b/_locales/uz/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "You don’t have permission to delete others’ messages",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Delete Messages",
   "deleted": "Deleted",

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -113,7 +113,7 @@
   "messageDeletionForbidden": "您無權刪除他人訊息",
   "deleteJustForMe": "Delete just for me",
   "deleteForEveryone": "Delete for everyone",
-  "deleteMessagesQuestion": "Delete those messages?",
+  "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "刪除訊息",
   "deleted": "已刪除",

--- a/ts/interactions/conversations/unsendingInteractions.ts
+++ b/ts/interactions/conversations/unsendingInteractions.ts
@@ -336,13 +336,14 @@ export async function deleteMessagesByIdForEveryone(
     await Promise.all(messageIds.map(m => getMessageById(m, false)))
   );
 
-  const moreThanOne = selectedMessages.length > 1;
+  const messageCount = selectedMessages.length;
+  const moreThanOne = messageCount > 1;
 
   window.inboxStore?.dispatch(
     updateConfirmModal({
       title: window.i18n('deleteForEveryone'),
       message: moreThanOne
-        ? window.i18n('deleteMessagesQuestion')
+        ? window.i18n('deleteMessagesQuestion', [messageCount.toString()])
         : window.i18n('deleteMessageQuestion'),
       okText: window.i18n('deleteForEveryone'),
       okTheme: SessionButtonColor.Danger,


### PR DESCRIPTION
### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

This is mainly for moderators. It simply shows how many messages the moderator has marked for deletion when asking for confirmation before going ahead.

<img width="409" alt="image" src="https://user-images.githubusercontent.com/749942/165006632-76be56d6-a09c-435d-8731-6a2f6bb174fc.png">

I've include modified translations for all of the languages that I know well enough to handle myself. Where other languages had no translation and still used English for the message in question, the English-language string has been modified.