### PR TITLE
Style message request counter as per conversation message count.

### DIFF
--- a/ts/components/leftpane/MessageRequestsBanner.tsx
+++ b/ts/components/leftpane/MessageRequestsBanner.tsx
@@ -47,7 +47,8 @@ const StyledCircleIcon = styled.div`
 const StyledUnreadCounter = styled.div`
   font-weight: bold;
   border-radius: var(--margins-sm);
-  background-color: var(--color-request-banner-unread-background);
+  background-color: var(--color-accent);
+  color: black;
   margin-left: 10px;
   min-width: 20px;
   height: 20px;


### PR DESCRIPTION
### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

This harmonises the styles of both unread counters in the left pane, following the recent acceptance of my patch to change the style of the per conversation unread message counter.