### PR TITLE
Migrate to MaxMind's GeoLite2 library for geolocation service.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "util-worker": {
       "source": "ts/webworker/workers/util.worker.ts",
       "distDir": "./ts/webworker/workers/",
-      "optimize" : true,
+      "optimize": true,
       "sourceMap": false,
       "context": "web-worker"
     }
@@ -66,7 +66,6 @@
     "classnames": "2.2.5",
     "color": "^3.1.2",
     "config": "1.28.1",
-    "country-code-lookup": "^0.0.19",
     "curve25519-js": "^0.0.4",
     "dompurify": "^2.0.7",
     "electron-is-dev": "^1.1.0",
@@ -78,13 +77,13 @@
     "fs-extra": "9.0.0",
     "glob": "7.1.2",
     "image-type": "^4.1.0",
-    "ip2country": "1.0.1",
     "jquery": "3.3.1",
     "jsbn": "1.1.0",
     "libsodium-wrappers-sumo": "^0.7.9",
     "linkify-it": "3.0.2",
     "lodash": "4.17.11",
     "long": "^4.0.0",
+    "maxmind": "^4.3.6",
     "mic-recorder-to-mp3": "^2.2.2",
     "moment": "2.21.0",
     "mustache": "2.3.0",
@@ -347,6 +346,9 @@
       "!node_modules/better-sqlite3/src/*",
       "node_modules/better-sqlite3/build/Release/better_sqlite3.node",
       "!dev-app-update.yml"
+    ],
+    "extraFiles": [
+      "mmdb/GeoLite2-Country.mmdb"
     ]
   }
 }

--- a/preload.js
+++ b/preload.js
@@ -1,6 +1,8 @@
 const { clipboard, ipcRenderer, webFrame } = require('electron/main');
 const { Storage } = require('./ts/util/storage');
 
+const path = require('path');
+const { readFileSync } = require('fs');
 const url = require('url');
 
 const config = url.parse(window.location.toString(), true).query;
@@ -222,6 +224,13 @@ window.getSeedNodeList = () => [
     url: 'https://public.loki.foundation:4433/',
   },
 ];
+
+// Ensure we can always find the GeoLite2 database, regardless of whether
+// this is a dev or a prod build.
+binPath = (process.env.NODE_APP_INSTANCE || '').startsWith('devprod')
+  ? path.resolve(__dirname)
+  : path.resolve(`${process.resourcesPath}/..`);
+window.mmdbBuffer = readFileSync(`${binPath}/mmdb/GeoLite2-Country.mmdb`);
 
 const { locale: localFromEnv } = config;
 window.i18n = setupi18n(localFromEnv, localeMessages);

--- a/ts/components/dialog/OnionStatusPathDialog.tsx
+++ b/ts/components/dialog/OnionStatusPathDialog.tsx
@@ -4,8 +4,7 @@ import { shell } from 'electron';
 
 import { useDispatch, useSelector } from 'react-redux';
 
-import ip2country from 'ip2country';
-import countryLookup from 'country-code-lookup';
+import { CountryResponse, Reader } from 'maxmind';
 import { Snode } from '../../data/data';
 import { onionPathModal } from '../../state/ducks/modalDialog';
 import {
@@ -45,6 +44,9 @@ const OnionCountryDisplay = ({
 
   return hoverable;
 };
+
+const reader = new Reader<CountryResponse>(window.mmdbBuffer);
+const lang = 'en';
 
 const OnionPathModalInner = () => {
   const onionPath = useSelector(getFirstOnionPath);
@@ -87,9 +89,12 @@ const OnionPathModalInner = () => {
           </div>
           <Flex container={true} flexDirection="column" alignItems="flex-start">
             {nodes.map((snode: Snode | any, index: number) => {
+	      const countryLookup = reader.get(snode.ip || '0.0.0.0');
+	      const countryName = countryLookup?.country?.names[lang];
+
               let labelText = snode.label
                 ? snode.label
-                : `${countryLookup.byIso(ip2country(snode.ip))?.country}`;
+                : countryName
               if (!labelText) {
                 labelText = window.i18n('unknownCountry');
               }

--- a/ts/window.d.ts
+++ b/ts/window.d.ts
@@ -42,7 +42,8 @@ declare global {
     onLogin: any;
     persistStore?: Persistor;
     restart: any;
-    getSeedNodeList: () => Array<any> | undefined;
+    getSeedNodeList: () => Array<string> | undefined;
+    mmdbBuffer: Buffer;
     setPassword: any;
     storage: any;
     isOnline: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2205,14 +2205,6 @@ asar@0.14.0:
     mksnapshot "^0.3.0"
     tmp "0.0.28"
 
-asbycountry@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/asbycountry/-/asbycountry-1.4.2.tgz#26bf0e090225b93f7d1fc5a177899c900b5c8258"
-  integrity sha512-NnIJ1lUYJ/M0XmoOA1T5uLQWbD81MDz5MpwufSHymw8j3DauFyTDki7ixxG8nMeUo5GBkFT1U/USOcz0mJnrNQ==
-  dependencies:
-    chalk "^1.1.3"
-    fetch "^1.1.0"
-
 asn1.js@^5.2.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-5.4.1.tgz#11a980b84ebb91781ce35b0fdc2ee294e3783f07"
@@ -2381,13 +2373,6 @@ bindings@^1.5.0:
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
-
-biskviit@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/biskviit/-/biskviit-1.0.1.tgz#037a0cd4b71b9e331fd90a1122de17dc49e420a7"
-  integrity sha1-A3oM1LcbnjMf2QoRIt4X3EnkIKc=
-  dependencies:
-    psl "^1.1.7"
 
 blob-util@2.0.2:
   version "2.0.2"
@@ -3129,11 +3114,6 @@ cosmiconfig@^7.0.1:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-country-code-lookup@^0.0.19:
-  version "0.0.19"
-  resolved "https://registry.yarnpkg.com/country-code-lookup/-/country-code-lookup-0.0.19.tgz#3fbf0192758ecf0d5eee0efbc220d62706c50fd6"
-  integrity sha512-lpvgdPyj8RuP0CSZhACNf5ueKlLbv/IQUAQfg7yr/qJbFrdcWV7Y+aDN9K/u/bx3MXRfcsjuW+TdIc0AEj7kDw==
-
 create-ecdh@^4.0.0:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"
@@ -3834,13 +3814,6 @@ encodeurl@^1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-encoding@0.1.12:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
-  dependencies:
-    iconv-lite "~0.4.13"
-
 end-of-stream@^1.1.0:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
@@ -4379,14 +4352,6 @@ fd-slicer@~1.1.0:
   integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
   dependencies:
     pend "~1.2.0"
-
-fetch@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fetch/-/fetch-1.1.0.tgz#0a8279f06be37f9f0ebb567560a30a480da59a2e"
-  integrity sha1-CoJ58Gvjf58Ou1Z1YKMKSA2lmi4=
-  dependencies:
-    biskviit "1.0.1"
-    encoding "0.1.12"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -5323,13 +5288,6 @@ invert-kv@^3.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-3.0.1.tgz#a93c7a3d4386a1dc8325b97da9bb1620c0282523"
   integrity sha512-CYdFeFexxhv/Bcny+Q0BfOV+ltRlJcd4BBZBYFX/O0u4npJrgZtIcjokegtiSMAvlMTJ+Koq0GBCc//3bueQxw==
 
-ip2country@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ip2country/-/ip2country-1.0.1.tgz#e2ab284b774b65c89509679fcb82552afcff9804"
-  integrity sha512-wYhIyQzcP85tKo17HwitnHB7F3vbN+gA7DqZzeE5K1NLfr4XnKZQ1RNsMGm3bNhf1eA3bz9QFjSXo4q6VKRqCw==
-  dependencies:
-    asbycountry "^1.4.2"
-
 ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
@@ -6070,6 +6028,14 @@ matcher@^3.0.0:
   dependencies:
     escape-string-regexp "^4.0.0"
 
+maxmind@^4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/maxmind/-/maxmind-4.3.6.tgz#5e4aa2491eef8bd401f34be307776fa1fb5bc3ca"
+  integrity sha512-CwnEZqJX0T6b2rWrc0/V3n9hL/hWAMEn7fY09077YJUHiHx7cn/esA2ZIz8BpYLSJUf7cGVel0oUJa9jMwyQpg==
+  dependencies:
+    mmdb-lib "2.0.2"
+    tiny-lru "8.0.2"
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -6293,6 +6259,11 @@ mksnapshot@^0.3.0:
     decompress-zip "0.3.x"
     fs-extra "0.26.7"
     request "2.x"
+
+mmdb-lib@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/mmdb-lib/-/mmdb-lib-2.0.2.tgz#fe60404142c0456c19607c72caa15821731ae957"
+  integrity sha512-shi1I+fCPQonhTi7qyb6hr7hi87R7YS69FlfJiMFuJ12+grx0JyL56gLNzGTYXPU7EhAPkMLliGeyHer0K+AVA==
 
 mocha-testcheck@1.0.0-rc.0:
   version "1.0.0-rc.0"
@@ -7307,7 +7278,7 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
-psl@^1.1.28, psl@^1.1.33, psl@^1.1.7:
+psl@^1.1.28, psl@^1.1.33:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
@@ -8784,6 +8755,11 @@ tiny-lr@^0.2.1:
     livereload-js "^2.2.0"
     parseurl "~1.3.0"
     qs "~5.1.0"
+
+tiny-lru@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/tiny-lru/-/tiny-lru-8.0.2.tgz#812fccbe6e622ded552e3ff8a4c3b5ff34a85e4c"
+  integrity sha512-ApGvZ6vVvTNdsmt676grvCkUCGwzG9IqXma5Z07xJgiC5L7akUMof5U8G2JTI9Rz/ovtVhJBlY6mNhEvtjzOIg==
 
 tmp@0.0.28:
   version "0.0.28"


### PR DESCRIPTION
This gives us more reliable data than the current ASN-based source.

Includes the GeoLite2 Country database from 2022-05-03.

### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

Before merging, please ensure that the inclusion and redistribution of the GeoLite2 database will comply with MaxMind's licensing terms for [commercial redistribution](https://www.maxmind.com/en/geolite2-commercial-redistribution).

It is not entirely clear whether Session falls outside of the definition of "commercial software" in its current state, but it may well enter into that category in the future if/when a Pro version of the software sees the light of day. In that event, a [commercial redistribution licence](https://www.maxmind.com/en/geolite-commercial-redistribution-license) will almost certainly be required.

This pull-request supersedes #2279, which used the MaxMind City database, and was judged to excessively increase the size of the binaries.