### PR TITLE
Make [Delete] and [Backspace] keys work the same as 'Delete' button.

### DIFF
--- a/ts/components/conversation/SessionConversation.tsx
+++ b/ts/components/conversation/SessionConversation.tsx
@@ -54,6 +54,7 @@ import { ConversationMessageRequestButtons } from './ConversationRequestButtons'
 import { ConversationRequestinfo } from './ConversationRequestInfo';
 import { getCurrentRecoveryPhrase } from '../../util/storage';
 import loadImage from 'blueimp-load-image';
+import { deleteMessagesByIdForEveryone } from '../../interactions/conversations/unsendingInteractions';
 // tslint:disable: jsx-curly-spacing
 
 interface State {
@@ -306,6 +307,12 @@ export class SessionConversation extends React.Component<Props, State> {
         case 'Escape':
           if (selectionMode) {
             window.inboxStore?.dispatch(resetSelectedMessageIds());
+          }
+	  break;
+        case 'Backspace':
+        case 'Delete':
+          if (selectionMode) {
+            void deleteMessagesByIdForEveryone(this.props.selectedMessages, this.props.selectedConversationKey);
           }
           break;
         default:


### PR DESCRIPTION
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

It would be good to have keyboard analogues for as much of the mouse-based functionality as possible.

To that end, this patch allows the `[Delete]` key to be used instead of mousing all the way to the top to click the red `Delete for everyone` button.