### PR TITLE
Report number of deletions when a deletion operation completes.

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -97,7 +97,7 @@
   "deleteMessagesQuestion": "Delete $count$ messages?",
   "deleteMessageQuestion": "Delete this message?",
   "deleteMessages": "Delete Messages",
-  "deleted": "Deleted",
+  "deleted": "$count$ deleted",
   "messageDeletedPlaceholder": "This message has been deleted",
   "from": "From:",
   "to": "To:",

--- a/ts/interactions/conversations/unsendingInteractions.ts
+++ b/ts/interactions/conversations/unsendingInteractions.ts
@@ -62,7 +62,7 @@ async function unsendMessagesForEveryone(
   await deleteMessagesFromSwarmAndCompletelyLocally(conversation, msgsToDelete);
 
   window.inboxStore?.dispatch(resetSelectedMessageIds());
-  ToastUtils.pushDeleted();
+  ToastUtils.pushDeleted(msgsToDelete.length);
 }
 
 function getUnsendMessagesObjects(messages: Array<MessageModel>) {
@@ -230,7 +230,7 @@ async function unsendMessageJustForThisUser(
 
   // Update view and trigger update
   window.inboxStore?.dispatch(resetSelectedMessageIds());
-  ToastUtils.pushDeleted();
+  ToastUtils.pushDeleted(msgsToDelete.length);
 }
 
 const doDeleteSelectedMessagesInSOGS = async (
@@ -270,7 +270,7 @@ const doDeleteSelectedMessagesInSOGS = async (
     })
   );
   // successful deletion
-  ToastUtils.pushDeleted();
+  ToastUtils.pushDeleted(toDeleteLocallyIds.length);
   window.inboxStore?.dispatch(resetSelectedMessageIds());
   //#endregion
 };
@@ -317,7 +317,7 @@ const doDeleteSelectedMessages = async ({
 
     // Update view and trigger update
     window.inboxStore?.dispatch(resetSelectedMessageIds());
-    ToastUtils.pushDeleted();
+    ToastUtils.pushDeleted(selectedMessages.length);
     return;
   }
   // otherwise, delete that message locally, from our swarm and from our other devices

--- a/ts/session/utils/Toast.tsx
+++ b/ts/session/utils/Toast.tsx
@@ -216,8 +216,8 @@ export function someDeletionsFailed() {
   pushToastWarning('deletionError', 'Deletion error');
 }
 
-export function pushDeleted() {
-  pushToastSuccess('deleted', window.i18n('deleted'), undefined, 'check');
+export function pushDeleted(messageCount: number) {
+  pushToastSuccess('deleted', window.i18n('deleted', [messageCount.toString()]), undefined, 'check');
 }
 
 export function pushCannotRemoveCreatorFromGroup() {


### PR DESCRIPTION
### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

This minor improvement reports the number of messages that were deleted when the operation completes.

<img width="233" alt="image" src="https://user-images.githubusercontent.com/749942/166922751-20f6ed7f-fb6c-46a2-8a8c-62a5958e32e1.png">
