### PR TITLE
Fix unfilled variable when user deletes messages only for himself.

### DIFF
--- a/ts/interactions/conversations/unsendingInteractions.ts
+++ b/ts/interactions/conversations/unsendingInteractions.ts
@@ -365,13 +365,14 @@ export async function deleteMessagesById(messageIds: Array<string>, conversation
     await Promise.all(messageIds.map(m => getMessageById(m, false)))
   );
 
+  const messageCount = selectedMessages.length;
   const moreThanOne = selectedMessages.length > 1;
 
   window.inboxStore?.dispatch(
     updateConfirmModal({
       title: window.i18n('deleteJustForMe'),
       message: moreThanOne
-        ? window.i18n('deleteMessagesQuestion')
+        ? window.i18n('deleteMessagesQuestion', [messageCount.toString()])
         : window.i18n('deleteMessageQuestion'),
       okText: window.i18n('delete'),
       okTheme: SessionButtonColor.Danger,


### PR DESCRIPTION
### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

The count was being filled when the user did a `Delete for everyone`, but not when doing a `Delete only for me`.