### PR TITLE
fix: emoji panel light mode support

### DIFF
--- a/stylesheets/_session_conversation.scss
+++ b/stylesheets/_session_conversation.scss
@@ -248,8 +248,8 @@
   & > section.emoji-mart {
     font-family: $session-font-default;
     font-size: $session-font-sm;
-    background-color: $session-shade-4;
-    border: 1px solid $session-shade-6-alt;
+    background-color: var(--color-cell-background);
+    border: 1px solid var(--color-session-border);
     border-radius: 8px;
     padding-bottom: $session-margin-sm;
 
@@ -259,7 +259,8 @@
       span {
         font-family: $session-font-default;
         padding-top: $session-margin-sm;
-        background-color: $session-shade-4;
+        background-color: var(--color-cell-background);
+        color: var(--color-text);
       }
     }
 
@@ -271,12 +272,25 @@
       cursor: pointer;
     }
 
-    .emoji-mart-bar:last-child {
-      border: none;
+    .emoji-mart-bar {
+        border-color: var(--color-session-border);
+
+      &:last-child {
+        border: none;
+      }
 
       .emoji-mart-preview {
         display: none;
       }
+    }
+
+    .emoji-mart-search {
+      input {
+        color: var(--color-text);
+        border-color: var(--color-session-border);
+        background-color: var(--color-input-background);
+      }
+
     }
 
     &:after {
@@ -286,11 +300,11 @@
       left: calc(100% - 79px);
       width: 22px;
       height: 22px;
-      background-color: $session-shade-4;
+      background-color: var(--color-cell-background);
       transform: rotate(45deg);
       border-radius: 3px;
       transform: scaleY(1.4) rotate(45deg);
-      border: 0.7px solid $session-shade-6-alt;
+      border: 0.7px solid var(--color-session-border);
       clip-path: polygon(100% 100%, 7.2px 100%, 100% 7.2px);
     }
   }

--- a/stylesheets/_session_conversation.scss
+++ b/stylesheets/_session_conversation.scss
@@ -2,14 +2,17 @@
   from {
     opacity: 1;
   }
+
   to {
     opacity: 0.25;
   }
 }
+
 @keyframes fromShadow {
   from {
     opacity: 0.25;
   }
+
   to {
     opacity: 1;
   }
@@ -19,9 +22,11 @@
   0% {
     box-shadow: 0px 0px 0px 0px $session-color-danger-alt;
   }
+
   50% {
     box-shadow: 0px 0px 12px 0px rgba($session-color-danger-alt, 1);
   }
+
   100% {
     box-shadow: 0px 0px 0px 0px rgba($session-color-danger-alt, 1);
   }
@@ -73,6 +78,7 @@
       display: flex;
     }
   }
+
   .message-selection-overlay div[role='button'] {
     display: inline-block;
   }
@@ -260,7 +266,6 @@
         font-family: $session-font-default;
         padding-top: $session-margin-sm;
         background-color: var(--color-cell-background);
-        color: var(--color-text);
       }
     }
 
@@ -272,25 +277,12 @@
       cursor: pointer;
     }
 
-    .emoji-mart-bar {
-        border-color: var(--color-session-border);
-
-      &:last-child {
-        border: none;
-      }
+    .emoji-mart-bar:last-child {
+      border: none;
 
       .emoji-mart-preview {
         display: none;
       }
-    }
-
-    .emoji-mart-search {
-      input {
-        color: var(--color-text);
-        border-color: var(--color-session-border);
-        background-color: var(--color-input-background);
-      }
-
     }
 
     &:after {
@@ -341,9 +333,11 @@
       0% {
         transform: scale(1);
       }
+
       80% {
         transform: scale(1.3);
       }
+
       100% {
         transform: scale(1);
       }
@@ -419,10 +413,12 @@
       &.primary {
         cursor: default;
         user-select: none;
+
         &:hover {
           filter: brightness(100%);
           border: 2px solid #161819;
         }
+
         background-color: $session-shade-1-alt;
         border: 2px solid #161819;
       }

--- a/ts/components/conversation/SessionEmojiPanel.tsx
+++ b/ts/components/conversation/SessionEmojiPanel.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames';
 import { Picker } from 'emoji-mart';
 import { Constants } from '../../session';
 import { useSelector } from 'react-redux';
-import { StateType } from '../../state/reducer';
 import { getTheme } from '../../state/selectors/theme';
 
 type Props = {
@@ -13,7 +12,7 @@ type Props = {
 
 export const SessionEmojiPanel = (props: Props) => {
   const { onEmojiClicked, show } = props;
-  const darkMode = useSelector((state: StateType) => getTheme(state)) === 'dark';
+  const darkMode = useSelector(getTheme) === 'dark';
 
   return (
     <div className={classNames('session-emoji-panel', show && 'show')}>

--- a/ts/components/conversation/SessionEmojiPanel.tsx
+++ b/ts/components/conversation/SessionEmojiPanel.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import classNames from 'classnames';
 import { Picker } from 'emoji-mart';
 import { Constants } from '../../session';
+import { useSelector } from 'react-redux';
+import { StateType } from '../../state/reducer';
+import { getTheme } from '../../state/selectors/theme';
 
 type Props = {
   onEmojiClicked: (emoji: any) => void;
@@ -10,6 +13,7 @@ type Props = {
 
 export const SessionEmojiPanel = (props: Props) => {
   const { onEmojiClicked, show } = props;
+  const darkMode = useSelector((state: StateType) => getTheme(state)) === 'dark';
 
   return (
     <div className={classNames('session-emoji-panel', show && 'show')}>
@@ -17,7 +21,7 @@ export const SessionEmojiPanel = (props: Props) => {
         backgroundImageFn={() => './images/emoji/emoji-sheet-twitter-32.png'}
         set={'twitter'}
         sheetSize={32}
-        darkMode={true}
+        darkMode={darkMode}
         color={Constants.UI.COLORS.GREEN}
         showPreview={true}
         title={''}


### PR DESCRIPTION
### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

Fixed emoji panel colors when using the light theme. Have tested swapping between themes on macOS.

## Before

<img width="420" alt="Screenshot 2022-05-10 at 17 43 17" src="https://user-images.githubusercontent.com/14887287/167576808-f60c0234-f5ec-4b2d-a675-b11f51e1c986.png">

## After

<img width="420" alt="Screenshot 2022-05-10 at 17 42 43" src="https://user-images.githubusercontent.com/14887287/167576844-8b5a30fd-2956-43f3-8cad-4b493137b58d.png">
