### PR TITLE
fix: added .parcel-cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.parcel-cache
 .sass-cache
 .eslintcache
 stylesheets/*.css.map


### PR DESCRIPTION
### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

We need to ignore the generated .parcel-cache folder since it builds every time we run `yarn grunt`. Tested on macOS.

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/loki-project/loki-messenger/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
