### PR TITLE
To aid debugging, don't redact strings when building for devprod.

### DIFF
--- a/ts/util/privacy.ts
+++ b/ts/util/privacy.ts
@@ -98,11 +98,9 @@ const removeNewlines = (text: string) => text.replace(/\r?\n|\r/g, '');
 //      redactSensitivePaths :: String -> String
 const redactSensitivePaths = redactPath(APP_ROOT_PATH);
 
+const isDev = (process.env.NODE_APP_INSTANCE || '').startsWith('devprod');
+
 //      redactAll :: String -> String
-export const redactAll = compose(
-  redactSensitivePaths,
-  redactGroupIds,
-  redactSessionID,
-  redactSnodeIP,
-  redactServerUrl
-);
+export const redactAll = !isDev
+  ? compose(redactSensitivePaths, redactGroupIds, redactSessionID, redactSnodeIP, redactServerUrl)
+  : (text: string) => text;


### PR DESCRIPTION
### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

I frequently find myself needing to patch out the redaction code in order to see where something is going wrong.

This patch applies no redaction to devprod builds, which seems entirely safe to me.