### PR TITLE
fixing the saved media read receipt

### DIFF
--- a/ts/receiver/contentMessage.ts
+++ b/ts/receiver/contentMessage.ts
@@ -636,8 +636,10 @@ export async function handleDataExtractionNotification(
   await removeFromCache(envelope);
 
   const convo = getConversationController().get(source);
-  if (!convo || !convo.isPrivate()) {
-    window?.log?.info('Got DataNotification for unknown or non private convo');
+  if (!convo || !convo.isPrivate() || !Storage.get(SettingsKey.settingsReadReceipt)) {
+    window?.log?.info(
+      'Got DataNotification for unknown or non private convo or read receipt not enabled'
+    );
     return;
   }
 

--- a/ts/session/messages/outgoing/controlMessage/DataExtractionNotificationMessage.ts
+++ b/ts/session/messages/outgoing/controlMessage/DataExtractionNotificationMessage.ts
@@ -6,6 +6,8 @@ import { PubKey } from '../../../types';
 import { getMessageQueue } from '../../..';
 import { getConversationController } from '../../../conversations';
 import { UserUtils } from '../../../utils';
+import { SettingsKey } from '../../../../data/settings-key';
+import { Storage } from '../../../../util/storage';
 interface DataExtractionNotificationMessageParams extends MessageParams {
   referencedAttachmentTimestamp: number;
 }
@@ -49,7 +51,13 @@ export const sendDataExtractionNotification = async (
   referencedAttachmentTimestamp: number
 ) => {
   const convo = getConversationController().get(conversationId);
-  if (!convo || !convo.isPrivate() || convo.isMe() || UserUtils.isUsFromCache(attachmentSender)) {
+  if (
+    !convo ||
+    !convo.isPrivate() ||
+    convo.isMe() ||
+    UserUtils.isUsFromCache(attachmentSender) ||
+    !Storage.get(SettingsKey.settingsReadReceipt)
+  ) {
     window.log.warn('Not sending saving attachment notification for', attachmentSender);
     return;
   }


### PR DESCRIPTION
Make sure the "media saved" notification is not sent/handled if the read receipt settings is disabled