### PR TITLE
fix: message text should wrap without causing extremely wide messages

### DIFF
--- a/stylesheets/_session.scss
+++ b/stylesheets/_session.scss
@@ -39,6 +39,7 @@ textarea {
   input,
   textarea {
     user-select: text;
+    word-break: break-all;
   }
 }
 


### PR DESCRIPTION
### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

When we have long messages with a link, the link wraps below the text and causes a large amount of white space. It would be better for the link text to wrap around.

Before:
<img width="884" alt="Screen Shot 2022-05-20 at 2 51 11 pm" src="https://user-images.githubusercontent.com/14887287/169452922-c67c5ca9-ec31-4788-916e-203f6a87d33e.png">

After:
<img width="639" alt="Screen Shot 2022-05-20 at 2 49 30 pm" src="https://user-images.githubusercontent.com/14887287/169452787-1b72c1c4-f81c-4415-9153-1b118d91f33b.png">

