### PR TITLE
When replying and later displaying replies, fill the whole quote line.

### DIFF
--- a/ts/models/conversation.ts
+++ b/ts/models/conversation.ts
@@ -623,7 +623,7 @@ export class ConversationModel extends Backbone.Model<ConversationAttributes> {
       author: quotedMessage.getSource(),
       id: `${quotedMessage.get('sent_at')}` || '',
       // no need to quote the full message length.
-      text: body?.slice(0, 100),
+      text: (body || '').length >= 320 ? `${body?.slice(0, 320)}…` : body,
       attachments: quotedAttachments,
       timestamp: quotedMessage.get('sent_at') || 0,
       convoId: this.id,

--- a/ts/models/message.ts
+++ b/ts/models/message.ts
@@ -1319,7 +1319,7 @@ export function sliceQuoteText(quotedText: string | undefined | null) {
   if (!quotedText || isEmpty(quotedText)) {
     return '';
   }
-  return quotedText.slice(0, 60);
+  return quotedText.slice(0, 180);
 }
 
 const throttledAllMessagesDispatch = _.debounce(


### PR DESCRIPTION
The current behaviour when replying to a message is to quote only the
first 100 characters when the new message is created.

When the new message is sent and rendered, only 60 of those 100
characters are actually displayed in the quoted area.

Since we have the width to display approximately 320 characters at
composition time, and 180 characters at rendering time (assuming a
full-screen client on a 4k desktop), let's use it.

### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

#### Before:

##### When composing:

<img width="785" alt="image" src="https://user-images.githubusercontent.com/749942/169797494-888a8c07-34a8-4651-971a-00862058a435.png">

Note how the text being quoted is truncated (100 chars), even though there is ample room to display it.

##### When rendered:

<img width="1001" alt="image" src="https://user-images.githubusercontent.com/749942/169797986-a1f4f942-cef5-4203-9457-c82d81fc9741.png">

Note how the quoted text has been truncated even further (60 chars), even though there is ample room to provide more context for the reply.

#### After:

##### When composing:

<img width="895" alt="image" src="https://user-images.githubusercontent.com/749942/169798368-2ac7f72e-d16f-4d98-b413-2cb9a731f9a3.png">

##### When rendered:

<img width="1007" alt="image" src="https://user-images.githubusercontent.com/749942/169799497-dd315f80-d2ca-4340-aa2d-f89eee85d305.png">

I hope you agree this is better. 180 characters will allow us to use the full length of the message bubble to display quoted text. And 320 characters will allow us to use the full width of the composition box.

Incidentally, it appears that non-desktop clients may include in replies much more quoted text than they actually display, so a performance optimisation can probably be had here on the mobile clients. There's no reason to include more of the quoted message than you actually display.