### PR TITLE
Clarify that clearing message requests also blocks the senders.

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -404,7 +404,7 @@
   "notificationSubtitle": "Notifications - $setting$",
   "surveyTitle": "Take our Session Survey",
   "goToOurSurvey": "Go to our survey",
-  "clearAll": "Clear All",
+  "clearAll": "Block All",
   "messageRequests": "Message Requests",
   "requestsSubtitle": "Pending Requests",
   "requestsPlaceholder": "No requests",
@@ -446,8 +446,8 @@
   "noMediaUntilApproved": "You cannot send attachments until the conversation is approved",
   "mustBeApproved": "This conversation must be accepted to use this feature",
   "youHaveANewFriendRequest": "You have a new friend request",
-  "clearAllConfirmationTitle": "Clear All Message Requests",
-  "clearAllConfirmationBody": "Are you sure you want to clear all message requests?",
+  "clearAllConfirmationTitle": "Block All Senders Of Message Requests",
+  "clearAllConfirmationBody": "Are you sure you want to block all message requests?",
   "hideBanner": "Hide",
   "openMessageRequestInboxDescription": "View your Message Request inbox"
 }


### PR DESCRIPTION
### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

The current text does not convey the severity of the underlying action.