### PR TITLE
Trim leading and trailing whitespace on message composition and display.

### DIFF
--- a/ts/components/conversation/composition/CompositionBox.tsx
+++ b/ts/components/conversation/composition/CompositionBox.tsx
@@ -843,7 +843,7 @@ class CompositionBoxInner extends React.Component<Props, State> {
       // this does not call call removeAllStagedAttachmentsInConvers
       const { attachments, previews } = await this.getFiles(linkPreview);
       this.props.sendMessage({
-        body: messagePlaintext,
+        body: messagePlaintext.trim(),
         attachments: attachments || [],
         quote: extractedQuotedMessageProps,
         preview: previews,

--- a/ts/components/conversation/message/message-content/MessageText.tsx
+++ b/ts/components/conversation/message/message-content/MessageText.tsx
@@ -31,7 +31,7 @@ export const MessageText = (props: Props) => {
     ? window.i18n('messageDeletedPlaceholder')
     : direction === 'incoming' && status === 'error'
     ? window.i18n('incomingError')
-    : text;
+    : text?.trim();
 
   if (!contents) {
     return null;


### PR DESCRIPTION
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

Session allows a message to be composed and sent with leading and/or trailing whitespace. It will also display any leading and/or trailing whitespace in messages it receives.

This patch fixes both problems. Newly composed messages will be trimmed before sending, as will incoming messages before they are displayed.

Untidy messages such as the following are no longer possible:

<img width="191" alt="image" src="https://user-images.githubusercontent.com/749942/172010240-3ef54312-5bec-4928-9e9e-d1b8ebca99b0.png">
