### PR TITLE
fix: handle missing logs folder when performing log rotations

### DIFF
--- a/patches/bunyan+1.8.15.patch
+++ b/patches/bunyan+1.8.15.patch
@@ -1,10 +1,26 @@
 diff --git a/node_modules/bunyan/lib/bunyan.js b/node_modules/bunyan/lib/bunyan.js
-index f988560..11af013 100644
+index f988560..a4cf69a 100644
 --- a/node_modules/bunyan/lib/bunyan.js
 +++ b/node_modules/bunyan/lib/bunyan.js
-@@ -76,7 +76,8 @@ if (runtimeEnv === 'browser') {
+@@ -63,7 +63,7 @@ if (!runtimeEnv) {
+ }
+
+
+-var os, fs, dtrace;
++var os, fs, pathModule, dtrace;
+ if (runtimeEnv === 'browser') {
+     os = {
+         hostname: function () {
+@@ -71,12 +71,15 @@ if (runtimeEnv === 'browser') {
+         }
+     };
+     fs = {};
++    pathModule = {};
+     dtrace = null;
+ } else {
      os = require('os');
      fs = require('fs');
++    pathModule = require('path');
      try {
 -        dtrace = require('dtrace-provider' + '');
 +        throw new Error('dtrace-provider is not available')
@@ -12,3 +28,16 @@ index f988560..11af013 100644
      } catch (e) {
          dtrace = null;
      }
+@@ -1512,6 +1515,12 @@ RotatingFileStream.prototype.rotate = function rotate() {
+     }
+
+     function finish() {
++        if (!fs.existsSync(self.path)) {
++            var dirPath = pathModule.dirname(self.path);
++            if (!fs.existsSync(dirPath)) {
++                fs.mkdirSync(dirPath, { recursive: true });
++            }
++        }
+         self._debug('  open %s', self.path);
+         self.stream = fs.createWriteStream(self.path,
+             {flags: 'a', encoding: 'utf8'});


### PR DESCRIPTION
### Description

[bunyan](https://www.npmjs.com/package/bunyan) doesnt check if the filepath exists before running the finish command after a log rotation, I've patched it to create the directory if it doesn't exist yet

Should fix https://github.com/oxen-io/session-desktop/issues/2278 and https://github.com/oxen-io/session-desktop/issues/2333

Tested on macOS, Ubuntu and Windows
