### PR TITLE
fix: global error dialog box's 'copy to clipboard' option shouldn't quit the app

### DIFF
--- a/ts/node/global_errors.ts
+++ b/ts/node/global_errors.ts
@@ -6,7 +6,7 @@ import { ConsoleCustom } from './logging'; // checked - only node
 
 // We use hard-coded strings until we're able to update these strings from the locale.
 let quitText = 'Quit';
-let copyErrorAndQuitText = 'Copy error and quit';
+let copyErrorAndQuitText = 'Copy error to clipboard';
 
 async function handleError(prefix: string, error: any) {
   if ((console as ConsoleCustom)._error) {
@@ -17,21 +17,21 @@ async function handleError(prefix: string, error: any) {
   if (app.isReady()) {
     // title field is not shown on macOS, so we don't use it
     const button = await dialog.showMessageBox({
-      buttons: [quitText, copyErrorAndQuitText],
+      buttons: [copyErrorAndQuitText, quitText],
       defaultId: 0,
       detail: redactAll(error.stack),
       message: prefix,
       noLink: true,
       type: 'error',
     });
-    if (button.response === 1) {
+    if (button.response === 0) {
       clipboard.writeText(`${prefix}\n\n${redactAll(error.stack)}`);
+    } else if (button.response === 1) {
+      app.exit(1);
     }
   } else {
     dialog.showErrorBox(prefix, error.stack);
   }
-
-  app.exit(1);
 }
 
 export const updateLocale = (messages: LocaleMessagesType) => {


### PR DESCRIPTION
### Description

The ElectronJS error dialog box has a button that copies the error to the clipboard. Right now it quits the app automatically when it's clicked. This is undesirable since we can't access the entire log file or debug the state using the Inspector Tools. 

This change only closes the dialog when the option is selected and doesn't quit the app. The user must explicitly choose the 'Quit' button to close the app after an error occurs.

#### Screenshot

<img width="582" alt="Screen Shot 2022-06-14 at 1 39 27 pm" src="https://user-images.githubusercontent.com/14887287/173504560-c1d6329b-f7a5-4756-ae0d-af03e119357f.png">
