### PR TITLE
configure desktop icon for linux appImages

### DIFF
--- a/ts/mains/main_node.ts
+++ b/ts/mains/main_node.ts
@@ -13,6 +13,7 @@ import {
 } from 'electron';
 
 import path, { join } from 'path';
+import { platform as osPlatform } from 'process';
 import url from 'url';
 import os from 'os';
 import fs from 'fs';
@@ -291,8 +292,11 @@ async function createWindow() {
       nativeWindowOpen: true,
       spellcheck: await getSpellCheckSetting(),
     },
+    // only set icon for Linux, the executable one will be used by default for other platforms
+    icon:
+      (osPlatform === 'linux' && path.join(getAppRootPath(), 'images/session/session_icon.png')) ||
+      undefined,
     ...picked,
-    // don't setup icon, the executable one will be used by default
   };
 
   if (!_.isNumber(windowOptions.width) || windowOptions.width < minWidth) {


### PR DESCRIPTION
The icon is missing on linux so appImages run with a blank icon in the toolbar. This adds the icon member to electrons `BrowserWindow` config for the linux platform only and should correctly display icons in the toolbar now.


![Screenshot from 2022-06-30 10-10-24](https://user-images.githubusercontent.com/2188604/176566467-630b5ddb-fa49-4fbd-beac-fe7e578ae457.png)
