### PR TITLE
fix: make sure existing sogs convo do not break on save

### DIFF
--- a/ts/node/sql.ts
+++ b/ts/node/sql.ts
@@ -1979,6 +1979,7 @@ function getConversationCount() {
 }
 
 // tslint:disable-next-line: max-func-body-length
+// tslint:disable-next-line: cyclomatic-complexity
 function saveConversation(data: ConversationAttributes, instance?: BetterSqlite3.Database) {
   const formatted = assertValidConversationAttributes(data);
 
@@ -2107,9 +2108,9 @@ function saveConversation(data: ConversationAttributes, instance?: BetterSqlite3
       groupAdmins: groupAdmins && groupAdmins.length ? arrayStrToJson(groupAdmins) : '[]',
       isKickedFromGroup: toSqliteBoolean(isKickedFromGroup),
       subscriberCount,
-      readCapability,
-      writeCapability,
-      uploadCapability,
+      readCapability: toSqliteBoolean(readCapability),
+      writeCapability: toSqliteBoolean(writeCapability),
+      uploadCapability: toSqliteBoolean(uploadCapability),
 
       is_medium_group: toSqliteBoolean(is_medium_group),
       avatarPointer,

--- a/ts/session/apis/open_group_api/opengroupV2/OpenGroupServerPoller.ts
+++ b/ts/session/apis/open_group_api/opengroupV2/OpenGroupServerPoller.ts
@@ -34,6 +34,9 @@ export type OpenGroupMessageV4 = {
 
 const pollForEverythingInterval = DURATION.SECONDS * 10;
 
+export const invalidAuthRequiresBlinding =
+  'Invalid authentication: this server requires the use of blinded ids';
+
 /**
  * An OpenGroupServerPollerV2 polls for everything for a particular server. We should
  * have only have one OpenGroupServerPollerV2 per opengroup polling.
@@ -295,9 +298,7 @@ export class OpenGroupServerPoller {
       ) {
         const bodyPlainText = (batchPollResults.body as any).plainText;
         // this is temporary (as of 27/06/2022) as we want to not support unblinded sogs after some time
-        if (
-          bodyPlainText === 'Invalid authentication: this server requires the use of blinded ids'
-        ) {
+        if (bodyPlainText === invalidAuthRequiresBlinding) {
           await fetchCapabilitiesAndUpdateRelatedRoomsOfServerUrl(this.serverUrl);
           throw new Error('batchPollResults just detected switch to blinded enforced.');
         }


### PR DESCRIPTION
the app was crashing if a convo with an invalid read/write/upload capability was saved during a migration
