### PR TITLE
Enable selection and copying of text of outgoing messages.

### DIFF
--- a/stylesheets/_session_theme.scss
+++ b/stylesheets/_session_theme.scss
@@ -95,6 +95,10 @@
     .module-message__text {
       color: var(--color-sent-message-text);
 
+      * {
+	user-select: text;
+      }
+
       a {
         text-decoration: underline;
         color: var(--color-sent-message-text);


### PR DESCRIPTION
<### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

This is a reopening of #2216.

In v1.9.1, it's still not possible to select and copy the text of one's own **sent** messages. Incoming messages **are** selectable, but outgoing are not.

The patch makes it possible to also select the text of sent messages.