### PR TITLE
fix: skip attachment without path when replying to a message

### DIFF
--- a/ts/models/conversation.ts
+++ b/ts/models/conversation.ts
@@ -507,62 +507,6 @@ export class ConversationModel extends Backbone.Model<ConversationAttributes> {
     return current;
   }
 
-  public async getQuoteAttachment(attachments: any, preview: any) {
-    if (attachments && attachments.length) {
-      return Promise.all(
-        attachments
-          .filter(
-            (attachment: any) =>
-              attachment && attachment.contentType && !attachment.pending && !attachment.error
-          )
-          .slice(0, 1)
-          .map(async (attachment: any) => {
-            const { fileName, thumbnail, contentType } = attachment;
-
-            return {
-              contentType,
-              // Our protos library complains about this field being undefined, so we
-              //   force it to null
-              fileName: fileName || null,
-              thumbnail: thumbnail
-                ? {
-                    ...(await loadAttachmentData(thumbnail)),
-                    objectUrl: getAbsoluteAttachmentPath(thumbnail.path),
-                  }
-                : null,
-            };
-          })
-      );
-    }
-
-    if (preview && preview.length) {
-      return Promise.all(
-        preview
-          .filter((item: any) => item && item.image)
-          .slice(0, 1)
-          .map(async (attachment: any) => {
-            const { image } = attachment;
-            const { contentType } = image;
-
-            return {
-              contentType,
-              // Our protos library complains about this field being undefined, so we
-              //   force it to null
-              fileName: null,
-              thumbnail: image
-                ? {
-                    ...(await loadAttachmentData(image)),
-                    objectUrl: getAbsoluteAttachmentPath(image.path),
-                  }
-                : null,
-            };
-          })
-      );
-    }
-
-    return [];
-  }
-
   public async makeQuote(quotedMessage: MessageModel): Promise<ReplyingToMessageProps | null> {
     const attachments = quotedMessage.get('attachments');
     const preview = quotedMessage.get('preview');
@@ -2098,6 +2042,66 @@ export class ConversationModel extends Backbone.Model<ConversationAttributes> {
       return moderatorsOrAdminsChanged;
     }
     return false;
+  }
+
+  private async getQuoteAttachment(attachments: any, preview: any) {
+    if (attachments?.length) {
+      return Promise.all(
+        attachments
+          .filter(
+            (attachment: any) =>
+              attachment &&
+              attachment.contentType &&
+              !attachment.pending &&
+              !attachment.error &&
+              attachment?.thumbnail?.path // loadAttachmentData throws if the thumbnail.path is not set
+          )
+          .slice(0, 1)
+          .map(async (attachment: any) => {
+            const { fileName, thumbnail, contentType } = attachment;
+
+            return {
+              contentType,
+              // Our protos library complains about this field being undefined, so we
+              //   force it to null
+              fileName: fileName || null,
+              thumbnail: thumbnail
+                ? {
+                    ...(await loadAttachmentData(thumbnail)),
+                    objectUrl: getAbsoluteAttachmentPath(thumbnail.path),
+                  }
+                : null,
+            };
+          })
+      );
+    }
+
+    if (preview?.length) {
+      return Promise.all(
+        preview
+          .filter((attachment: any) => attachment?.image?.path) // loadAttachmentData throws if the image.path is not set
+          .slice(0, 1)
+          .map(async (attachment: any) => {
+            const { image } = attachment;
+            const { contentType } = image;
+
+            return {
+              contentType,
+              // Our protos library complains about this field being undefined, so we
+              //   force it to null
+              fileName: null,
+              thumbnail: image
+                ? {
+                    ...(await loadAttachmentData(image)),
+                    objectUrl: getAbsoluteAttachmentPath(image.path),
+                  }
+                : null,
+            };
+          })
+      );
+    }
+
+    return [];
   }
 }
 


### PR DESCRIPTION
This can happen if the attachment is still downloading, or could not be
downloaded. The message will have attachments or thumbnails, without
valid data associated to it.
This fix makes sure we don't try to load invalid paths when trying to
gather the attachments and previews
