### PR TITLE
fix: Fixed Reaction text alignment in the React List modal

### DIFF
--- a/ts/components/conversation/message/reactions/Reaction.tsx
+++ b/ts/components/conversation/message/reactions/Reaction.tsx
@@ -24,7 +24,6 @@ const StyledReaction = styled.button<{ selected: boolean; inModal: boolean; show
   margin: 0 4px var(--margins-sm);
   height: 24px;
   min-width: ${props => (props.showCount ? '48px' : '24px')};
-  ${props => props.inModal && 'width: 100%;'}
 
   span {
     width: 100%;
@@ -35,7 +34,7 @@ const StyledReactionContainer = styled.div<{
   inModal: boolean;
 }>`
   position: relative;
-  ${props => props.inModal && 'margin-right: 8px;'}
+  ${props => props.inModal && 'white-space: nowrap; margin-right: 8px;'}
 `;
 
 export type ReactionProps = {


### PR DESCRIPTION
This is pretty nuanced, but when we have flex nowrap the descendants can be squished so we have to force no wrapping.