### PR TITLE
Hotfix Message Reactions Width

### DIFF
--- a/ts/components/conversation/message/message-content/MessageReactions.tsx
+++ b/ts/components/conversation/message/message-content/MessageReactions.tsx
@@ -21,8 +21,8 @@ const StyledMessageReactionsContainer = styled(Flex)<{ x: number; y: number }>`
   }
 `;
 
-export const StyledMessageReactions = styled(Flex)<{ inModal: boolean }>`
-  ${props => (props.inModal ? '' : 'max-width: 320px;')}
+export const StyledMessageReactions = styled(Flex)<{ fullWidth: boolean }>`
+  ${props => (props.fullWidth ? '' : 'max-width: 640px;')}
 `;
 
 const StyledReactionOverflow = styled.button`
@@ -63,7 +63,7 @@ const Reactions = (props: ReactionsProps): ReactElement => {
       container={true}
       flexWrap={inModal ? 'nowrap' : 'wrap'}
       alignItems={'center'}
-      inModal={inModal}
+      fullWidth={inModal}
     >
       {reactions.map(([emoji, _]) => (
         <Reaction key={`${messageId}-${emoji}`} emoji={emoji} {...props} />
@@ -83,7 +83,7 @@ const CompressedReactions = (props: ExpandReactionsProps): ReactElement => {
       container={true}
       flexWrap={inModal ? 'nowrap' : 'wrap'}
       alignItems={'center'}
-      inModal={inModal}
+      fullWidth={true}
     >
       {reactions.slice(0, 4).map(([emoji, _]) => (
         <Reaction key={`${messageId}-${emoji}`} emoji={emoji} {...props} />

--- a/ts/components/dialog/ReactListModal.tsx
+++ b/ts/components/dialog/ReactListModal.tsx
@@ -55,6 +55,7 @@ const StyledReactionBar = styled(Flex)`
     span:nth-child(1) {
       margin: 0 8px;
       color: var(--color-text);
+      white-space: nowrap;
     }
 
     span:nth-child(2) {


### PR DESCRIPTION
- Prevent message reactions wrapping when in a compressed state.

Before:
<img width="706" alt="Screen Shot 2022-09-15 at 11 23 13 am" src="https://user-images.githubusercontent.com/14887287/190291383-58ff2d2d-43fb-4f7a-be81-78fa9f20e57e.png">

After:
<img width="1181" alt="Screen Shot 2022-09-15 at 10 59 38 am" src="https://user-images.githubusercontent.com/14887287/190291427-20d0cb67-2e23-4841-89b3-94e3eb631c80.png">

- When message reactions are expanded we will show a maximum of 10 emojis in a row.

Before:
<img width="1072" alt="Screen Shot 2022-09-15 at 11 24 58 am" src="https://user-images.githubusercontent.com/14887287/190291554-ee501521-2782-4d05-9cb4-c84afcc96a04.png">

After:
<img width="1195" alt="Screen Shot 2022-09-15 at 10 18 25 am" src="https://user-images.githubusercontent.com/14887287/190291499-95c3bbe1-33f8-4702-b715-7476d2424012.png">

- Fix alignment of complex emojis in the React List Modal