### PR TITLE
Retitle left panel 'Conversations', since that's what it displays.

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -71,7 +71,7 @@
   "noSearchResults": "No results found for \"$searchTerm$\"",
   "conversationsHeader": "Contacts and Groups",
   "contactsHeader": "Contacts",
-  "messagesHeader": "Messages",
+  "messagesHeader": "Conversations",
   "settingsHeader": "Settings",
   "typingAlt": "Typing animation for this conversation",
   "contactAvatarAlt": "Avatar for contact $name$",


### PR DESCRIPTION
### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

The left panel is currently titled *Messages*, but it contains conversations, not messages. The panel to its right contains messages.

Logically, the left panel should be titled *Conversations*. This patch makes the change.