### PR TITLE
Left-align outgoing messages with incoming messages.

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -46,7 +46,7 @@
 }
 
 .module-message__error--outgoing {
-  left: 8px;
+  right: 8px;
 }
 
 .module-message__error--incoming {

--- a/stylesheets/_session.scss
+++ b/stylesheets/_session.scss
@@ -304,8 +304,8 @@ textarea {
   margin-inline-end: auto;
 }
 .module-message--outgoing {
-  margin-inline-end: 0;
-  margin-inline-start: auto;
+  margin-inline-start: 0;
+  margin-inline-end: auto;
 }
 
 pre {

--- a/ts/components/conversation/message/message-content/MessageAvatar.tsx
+++ b/ts/components/conversation/message/message-content/MessageAvatar.tsx
@@ -48,16 +48,11 @@ export const MessageAvatar = (props: Props) => {
     authorName,
     sender,
     authorProfileName,
-    conversationType,
-    direction,
     isSenderAdmin,
     lastMessageOfSeries,
     isPublic,
   } = avatarProps;
 
-  if (conversationType !== 'group' || direction === 'outgoing') {
-    return null;
-  }
   const userName = authorName || authorProfileName || sender;
 
   const onMessageAvatarClick = useCallback(async () => {


### PR DESCRIPTION
### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

The paradigm of displaying incoming messages on the left-hand side of the screen and outgoing on the right is the legacy of Session's origin as a fork of Signal.

Not only does this consume a lot of screen space, it's also unnecessary, as outgoing messages are already distinguished from incoming by their colour, i.e. a green background vs. a grey one. Outgoing messages also omit the avatar, which deprives the sender of a quick visual confirmation that his avatar is as expected. (Session has been known to reset a sender's avatar on occasion).

To add the sender's avatar on the right, a vertical margin would have to be reserved, leading to even poorer utilisation of the available screen space.

This patch moves outgoing messages to the right-hand side of the screen, aligning them with incoming messages, and displays the sender's avatar alongside them for consistency.

Additionally, I dispense with the distinction between groups and 1-to-1 chats, displaying avatars in all cases.

<img width="903" alt="image" src="https://user-images.githubusercontent.com/749942/190859404-c83ed832-85c4-44cb-8edc-ebf50f819668.png">
