### PR TITLE
Allow user display names of up to 64 bytes.

### DIFF
--- a/ts/components/registration/RegistrationStages.tsx
+++ b/ts/components/registration/RegistrationStages.tsx
@@ -17,7 +17,7 @@ import {
 import { fromHex } from '../../session/utils/String';
 import { setSignInByLinking, setSignWithRecoveryPhrase, Storage } from '../../util/storage';
 
-export const MAX_USERNAME_LENGTH = 26;
+export const MAX_USERNAME_LENGTH = 64;
 // tslint:disable: use-simple-attributes
 
 export async function resetRegistration() {


### PR DESCRIPTION
Currently, only 26 bytes are allowed for the user's display name. Whilst this is typically enough for users in the West, it is woefully inadequate for names natively rendered in non-Latin scripts.

Farsi, for example, uses double-byte characters, so 26 bytes can accommodate a maximum of just 13 characters.

The situation is worse yet for Japanese, Korean, Chinese and Thai, each of which uses triple-byte characters for a maximum of just 8 characters.

This patch increases the maximum size of the display name to 64 bytes, good for a minimum of 21 graphemes in even a triple-byte UTF-8 script.

64 bytes also happens to be the maximum length of an ONS registration for Session, and it seems entirely reasonable to allow users to have their ONS name as their display name.

See also [#981](https://github.com/oxen-io/session-android/pull/981) for the equivalent fix for the Android client.

### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users