### PR TITLE
Set the Windows spell-checking language from $LANGUAGE.

### DIFF
--- a/ts/node/spell_check.ts
+++ b/ts/node/spell_check.ts
@@ -5,7 +5,9 @@ import { sync as osLocaleSync } from 'os-locale';
 
 export const setup = (browserWindow: BrowserWindow, messages: any) => {
   const { session } = browserWindow.webContents;
-  const userLocale = osLocaleSync().replace(/_/g, '-');
+  const userLocale = process.env.LANGUAGE
+    ? process.env.LANGUAGE
+    : osLocaleSync().replace(/_/g, '-');
   const userLocales = [userLocale, userLocale.split('-')[0]];
 
   const available = session.availableSpellCheckerLanguages;


### PR DESCRIPTION
Session on Windows wants to spell-check using American English, no matter what I do. This seems to be because it wrongly assumes my locale to be `en-US`, when it is actually `en-GB`.

```
"spellcheck: setting languages to:  [\"en-US\"]","time":"2022-10-10T19:19:09.216Z"
```

With this patch, Windows will use `$LANGUAGE`, if set, to determine the language to be used for spell-checking.

Linux is unaffected by this patch and will correctly infer the spell-checking language from `$LANG`.

Create a .bat file and start Session from this:

```
@echo off
set LANGUAGE=en-GB
"C:\Users\ian\AppData\Local\Programs\Session\Session.exe" --lang=en-GB
```

Note that the use of `--lang=<language>` above sets only the Session UI language, not the spell-checker language.

This is a partial fix for oxen-io/session-desktop-temp#527, specifically [this comment](https://github.com/oxen-io/session-desktop-temp/issues/527):

### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users
