### PR TITLE
Fix .deb Section

### DIFF
--- a/package.json
+++ b/package.json
@@ -306,7 +306,8 @@
         "libnss3",
         "libasound2",
         "libxss1"
-      ]
+      ],
+      "packageCategory": "net"
     },
     "files": [
       "package.json",


### PR DESCRIPTION
Currently the deb gets created with `Section: default` in the metadata, which isn't a valid debian section at all; this fixes it to be `net` to properly categorize it in deb package managers.