### PR TITLE
Use --frozen-lockfile by default when running yarn install

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--install.frozen-lockfile true


### PR DESCRIPTION
- This is a DX improvement
- As already documented if you use `--frozen-lockfile` it makes sure that the environment is consistent on any machine by installing the exact package versions listed in the yarn.lock.