### PR TITLE
Generate 256-bit ed25519 keypairs instead of 128-bit keypairs.

### DIFF
--- a/ts/util/accountManager.ts
+++ b/ts/util/accountManager.ts
@@ -129,7 +129,9 @@ export async function registerSingleDevice(
 export async function generateMnemonic() {
   // Note: 4 bytes are converted into 3 seed words, so length 12 seed words
   // (13 - 1 checksum) are generated using 12 * 4 / 3 = 16 bytes.
-  const seedSize = 16;
+  //
+  // For 24 seed words (256 bit keys), we need 32 bytes.
+  const seedSize = 32;
   const seed = (await getSodiumRenderer()).randombytes_buf(seedSize);
   const hex = toHex(seed);
   return mn_encode(hex);


### PR DESCRIPTION
### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

There appears to be no good reason for Session not to generate 256-bit (32-byte) ed25519 keypairs for users to use, rather than the current 128-bit keypairs.

Session already accepts these longer keys, but provides no way for the user to actually generate them internally.

Some users theorise that the use of 128-bit ed25519 keys is actually unsafe at this point in time, and have therefore resorted to generating 256-bit keys by external means. Whilst I believe this to be based on a flawed understanding of the underlying mathematics, I see no reason for Session not to transition to generating 256-bit keys by default.

Virtually no user commits his recovery phrase to memory, and the storage and retrieval of a 25-word recovery phrase is no more complex than that of a 13-word phrase.

![image](https://user-images.githubusercontent.com/749942/209855657-d75cafbc-033b-4376-bbd2-851bf87ec2d1.png)
