### PR TITLE
Use correct verbiage ('clear' vs. 'block') in mod's emoji removal panel.

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -486,6 +486,7 @@
   "clearAllConfirmationBody": "Are you sure you want to clear all message requests?",
   "hideBanner": "Hide",
   "openMessageRequestInboxDescription": "View your Message Request inbox",
+  "removeAll": "Clear all",
   "clearAllReactions": "Are you sure you want to clear all $emoji$ ?",
   "expandedReactionsText": "Show Less",
   "reactionNotification": "Reacts to a message with $emoji$",

--- a/ts/components/dialog/ReactListModal.tsx
+++ b/ts/components/dialog/ReactListModal.tsx
@@ -355,7 +355,7 @@ export const ReactListModal = (props: Props): ReactElement => {
               </p>
               {isPublic && weAreModerator && (
                 <SessionButton
-                  text={window.i18n('clearAll')}
+                  text={window.i18n('removeAll')}
                   buttonColor={SessionButtonColor.Danger}
                   buttonType={SessionButtonType.Simple}
                   onClick={handleClearReactions}

--- a/ts/types/LocalizerKeys.ts
+++ b/ts/types/LocalizerKeys.ts
@@ -93,6 +93,7 @@ export type LocalizerKeys =
   | 'enterSessionIDOfRecipient'
   | 'join'
   | 'dialogClearAllDataDeletionFailedMultiple'
+  | 'removeAll'
   | 'clearAllReactions'
   | 'appMenuQuit'
   | 'windowMenuZoom'


### PR DESCRIPTION
### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

The moderator's emoji management panel refers to _blocking_ emojis rather than _clearing_ them. This is incorrect and confusing.

The code is also confusing, because the `clearAll` string has the text `Block All`, so I had to create a new string called `removeAll`.