### PR TITLE
Provide a helpful link to sessioncommunities.online.

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -432,6 +432,7 @@
   "recoveryPhraseRevealMessage": "Secure your account by saving your recovery phrase. Reveal your recovery phrase then store it safely to secure it.",
   "recoveryPhraseRevealButtonText": "Reveal Recovery Phrase",
   "notificationSubtitle": "Notifications - $setting$",
+  "openGroupsTitle": "Find more (unofficial) Session communities.",
   "surveyTitle": "We'd Love Your Feedback",
   "faq": "FAQ",
   "support": "Support",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -499,5 +499,6 @@
   "reactionPopupThree": "$name$, $name2$ & $name3$",
   "reactionPopupMany": "$name$, $name2$, $name3$ &",
   "reactionListCountSingular": "And $otherSingular$ has reacted <span>$emoji$</span> to this message",
-  "reactionListCountPlural": "And $otherPlural$ have reacted <span>$emoji$</span> to this message"
+  "reactionListCountPlural": "And $otherPlural$ have reacted <span>$emoji$</span> to this message",
+  "launchingCommunityBrowser": "Launching communities in browser..."
 }

--- a/ts/components/leftpane/ActionsPanel.tsx
+++ b/ts/components/leftpane/ActionsPanel.tsx
@@ -40,8 +40,8 @@ import { forceRefreshRandomSnodePool } from '../../session/apis/snode_api/snodeP
 import { Avatar, AvatarSize } from '../avatar/Avatar';
 import { SessionIconButton } from '../icon';
 import { LeftPaneSectionContainer } from './LeftPaneSectionContainer';
-import { ipcRenderer } from 'electron';
-import { UserUtils } from '../../session/utils';
+import { ipcRenderer, shell } from 'electron';
+import { ToastUtils, UserUtils } from '../../session/utils';
 
 import { getLatestReleaseFromFileServer } from '../../session/apis/file_server_api/FileServerApi';
 import { switchThemeTo } from '../../themes/switchTheme';
@@ -118,6 +118,20 @@ const Section = (props: { type: SectionType }) => {
           dataTestId="settings-section"
           iconType={'gear'}
           onClick={handleClick}
+          isSelected={isSelected}
+        />
+      );
+    case SectionType.Communities:
+      return (
+        <SessionIconButton
+          iconSize="medium"
+          dataTestId="communities-section"
+          iconType={'communities'}
+          onClick={() => {
+	    void shell.openExternal('https://sessioncommunities.online');
+	    ToastUtils.pushToastSuccess('launch', window.i18n('launchingCommunityBrowser'))
+	    }
+	  }
           isSelected={isSelected}
         />
       );
@@ -288,6 +302,7 @@ export const ActionsPanel = () => {
         <Section type={SectionType.Profile} />
         <Section type={SectionType.Message} />
         <Section type={SectionType.Settings} />
+        <Section type={SectionType.Communities} />
 
         <Section type={SectionType.PathIndicator} />
         <Section type={SectionType.ColorMode} />

--- a/ts/components/settings/section/CategoryHelp.tsx
+++ b/ts/components/settings/section/CategoryHelp.tsx
@@ -19,6 +19,10 @@ export const SettingsCategoryHelp = (props: { hasPassword: boolean | null }) => 
           description={window.i18n('shareBugDetails')}
         />
         <SessionSettingsTitleWithLink
+          title={window.i18n('openGroupsTitle')}
+          onClick={() => void shell.openExternal('https://sessioncommunities.online')}
+        />
+        <SessionSettingsTitleWithLink
           title={window.i18n('surveyTitle')}
           onClick={() => void shell.openExternal('https://getsession.org/survey')}
         />

--- a/ts/state/ducks/section.tsx
+++ b/ts/state/ducks/section.tsx
@@ -10,6 +10,7 @@ export enum SectionType {
   Profile,
   Message,
   Settings,
+  Communities,
   ColorMode,
   PathIndicator,
 }

--- a/ts/types/LocalizerKeys.ts
+++ b/ts/types/LocalizerKeys.ts
@@ -372,6 +372,7 @@ export type LocalizerKeys =
   | 'closedGroupInviteSuccessMessage'
   | 'youDisabledDisappearingMessages'
   | 'updateGroupDialogTitle'
+  | 'openGroupsTitle'
   | 'surveyTitle'
   | 'userRemovedFromModerators'
   | 'timerOption_5_seconds'

--- a/ts/types/LocalizerKeys.ts
+++ b/ts/types/LocalizerKeys.ts
@@ -499,4 +499,5 @@ export type LocalizerKeys =
   | 'displayNameTooLong'
   | 'joinedTheGroup'
   | 'editGroupName'
-  | 'reportIssue';
+  | 'reportIssue'
+  | 'launchingCommunityBrowser';


### PR DESCRIPTION
sessioncommunities.online is a semi-automated directory of Session open groups (a.k.a. communities). It has quickly become perhaps the best resource the Session community has for cataloguing the vast and growing resource of open groups.

As such, sessioncommunities.online has also quickly become the de facto answer to the frequently asked question 'Where can I find more open groups?'

Considering the above, the time would appear to be ripe to include a helpful link to the site from within Session itself.

<img width="628" alt="image" src="https://user-images.githubusercontent.com/749942/212486971-f96d1ead-7a91-4558-8a3f-51909f7e2fab.png">

### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

