### PR TITLE
fix: on cancel link preview toggle, toggle stays off

### DIFF
--- a/ts/components/settings/section/CategoryPrivacy.tsx
+++ b/ts/components/settings/section/CategoryPrivacy.tsx
@@ -12,21 +12,7 @@ import { TypingBubble } from '../../conversation/TypingBubble';
 import { SessionSettingButtonItem, SessionToggleWithDescription } from '../SessionSettingListItem';
 import { displayPasswordModal } from '../SessionSettings';
 
-async function toggleLinkPreviews() {
-  const newValue = !window.getSettingValue(SettingsKey.settingsLinkPreview);
-  await window.setSettingValue(SettingsKey.settingsLinkPreview, newValue);
-  if (!newValue) {
-    await Data.createOrUpdateItem({ id: hasLinkPreviewPopupBeenDisplayed, value: false });
-  } else {
-    window.inboxStore?.dispatch(
-      updateConfirmModal({
-        title: window.i18n('linkPreviewsTitle'),
-        message: window.i18n('linkPreviewsConfirmMessage'),
-        okTheme: SessionButtonColor.Danger,
-      })
-    );
-  }
-}
+
 
 const TypingBubbleItem = () => {
   return (
@@ -41,8 +27,31 @@ export const SettingsCategoryPrivacy = (props: {
   hasPassword: boolean | null;
   onPasswordUpdated: (action: string) => void;
 }) => {
+
+  const [isLinkPreviewsOn, setIsLinkPreviewsOn] = React.useState(Boolean(window.getSettingValue(SettingsKey.settingsLinkPreview)))
+  
+  async function toggleLinkPreviews() {
+  const newValue = !isLinkPreviewsOn
+    await window.setSettingValue(SettingsKey.settingsLinkPreview, newValue);
+    setIsLinkPreviewsOn(newValue)
+  if (!newValue) {
+    await Data.createOrUpdateItem({ id: hasLinkPreviewPopupBeenDisplayed, value: false });
+    setIsLinkPreviewsOn(false)
+  } else {
+    window.inboxStore?.dispatch(
+      updateConfirmModal({
+        title: window.i18n('linkPreviewsTitle'),
+        message: window.i18n('linkPreviewsConfirmMessage'),
+        okTheme: SessionButtonColor.Danger,
+        onClickCancel: async () => {
+            await window.setSettingValue(SettingsKey.settingsLinkPreview, Boolean(false));
+            setIsLinkPreviewsOn(false)},
+      })
+    );
+  }
+}
+  
   const forceUpdate = useUpdate();
-  const isLinkPreviewsOn = Boolean(window.getSettingValue(SettingsKey.settingsLinkPreview));
 
   if (props.hasPassword !== null) {
     return (

--- a/ts/components/settings/section/CategoryPrivacy.tsx
+++ b/ts/components/settings/section/CategoryPrivacy.tsx
@@ -12,7 +12,8 @@ import { TypingBubble } from '../../conversation/TypingBubble';
 import { SessionSettingButtonItem, SessionToggleWithDescription } from '../SessionSettingListItem';
 import { displayPasswordModal } from '../SessionSettings';
 
-async function toggleLinkPreviews(isToggleOn: boolean, setIsToggleOn: (value: boolean) => void) {
+async function toggleLinkPreviews(forceUpdate: () => void) {
+  const isToggleOn = Boolean(window.getSettingValue(SettingsKey.settingsLinkPreview));
   if (!isToggleOn) {
     window.inboxStore?.dispatch(
       updateConfirmModal({
@@ -22,13 +23,14 @@ async function toggleLinkPreviews(isToggleOn: boolean, setIsToggleOn: (value: bo
         onClickOk: async () => {
           const newValue = !isToggleOn;
           await window.setSettingValue(SettingsKey.settingsLinkPreview, newValue);
-          setIsToggleOn(newValue);
+          forceUpdate();
         },
       })
     );
   } else {
+    await window.setSettingValue(SettingsKey.settingsLinkPreview, false);
     await Data.createOrUpdateItem({ id: hasLinkPreviewPopupBeenDisplayed, value: false });
-    setIsToggleOn(false);
+    forceUpdate();
   }
 }
 
@@ -45,9 +47,7 @@ export const SettingsCategoryPrivacy = (props: {
   hasPassword: boolean | null;
   onPasswordUpdated: (action: string) => void;
 }) => {
-  const [isLinkPreviewsOn, setIsLinkPreviewsOn] = React.useState(
-    Boolean(window.getSettingValue(SettingsKey.settingsLinkPreview))
-  );
+  const isLinkPreviewsOn = Boolean(window.getSettingValue(SettingsKey.settingsLinkPreview));
 
   const forceUpdate = useUpdate();
 
@@ -77,8 +77,7 @@ export const SettingsCategoryPrivacy = (props: {
         />
         <SessionToggleWithDescription
           onClickToggle={async () => {
-            await toggleLinkPreviews(isLinkPreviewsOn, setIsLinkPreviewsOn);
-            forceUpdate();
+            await toggleLinkPreviews(forceUpdate);
           }}
           title={window.i18n('linkPreviewsTitle')}
           description={window.i18n('linkPreviewDescription')}

--- a/ts/components/settings/section/CategoryPrivacy.tsx
+++ b/ts/components/settings/section/CategoryPrivacy.tsx
@@ -50,7 +50,6 @@ export const SettingsCategoryPrivacy = (props: {
   const isLinkPreviewsOn = Boolean(window.getSettingValue(SettingsKey.settingsLinkPreview));
 
   const forceUpdate = useUpdate();
-
   if (props.hasPassword !== null) {
     return (
       <>

--- a/ts/components/settings/section/CategoryPrivacy.tsx
+++ b/ts/components/settings/section/CategoryPrivacy.tsx
@@ -47,9 +47,9 @@ export const SettingsCategoryPrivacy = (props: {
   hasPassword: boolean | null;
   onPasswordUpdated: (action: string) => void;
 }) => {
+  const forceUpdate = useUpdate();
   const isLinkPreviewsOn = Boolean(window.getSettingValue(SettingsKey.settingsLinkPreview));
 
-  const forceUpdate = useUpdate();
   if (props.hasPassword !== null) {
     return (
       <>


### PR DESCRIPTION
Here is a video of the new (and expected behavior).
First click clicks on cancel, and the toggle is not turned on. Second click clicks on accept, and the toggle turns ON (only once accept is pressed and not beforehand)

[Screencast from 31-03-23 09:55:57.webm](https://user-images.githubusercontent.com/1544279/228982821-d8e3acae-7ba2-4e3f-9971-46f17939becb.webm)
