### PR TITLE
Allow any number of pasted images as attachments.

### DIFF
--- a/ts/state/ducks/stagedAttachments.ts
+++ b/ts/state/ducks/stagedAttachments.ts
@@ -37,12 +37,8 @@ const stagedAttachmentsSlice = createSlice({
       }
 
       const allAttachments = _.concat(currentStagedAttachments, newAttachments);
-      const pastedAttachments = allAttachments.filter(m => m.fileName === 'image.png');
-      const allAttachmentsExceptPasted = allAttachments.filter(m => m.fileName !== 'image.png');
-      const uniqAttachments = _.uniqBy(allAttachmentsExceptPasted, m => m.fileName);
-      const finalAttachments =  _.concat(uniqAttachments, pastedAttachments);
 
-      state.stagedAttachments[conversationKey] = finalAttachments;
+      state.stagedAttachments[conversationKey] = allAttachments;
       return state;
     },
     removeAllStagedAttachmentsInConversation(

--- a/ts/state/ducks/stagedAttachments.ts
+++ b/ts/state/ducks/stagedAttachments.ts
@@ -37,9 +37,12 @@ const stagedAttachmentsSlice = createSlice({
       }
 
       const allAttachments = _.concat(currentStagedAttachments, newAttachments);
-      const uniqAttachments = _.uniqBy(allAttachments, m => m.fileName);
+      const pastedAttachments = allAttachments.filter(m => m.fileName === 'image.png');
+      const allAttachmentsExceptPasted = allAttachments.filter(m => m.fileName !== 'image.png');
+      const uniqAttachments = _.uniqBy(allAttachmentsExceptPasted, m => m.fileName);
+      const finalAttachments =  _.concat(uniqAttachments, pastedAttachments);
 
-      state.stagedAttachments[conversationKey] = uniqAttachments;
+      state.stagedAttachments[conversationKey] = finalAttachments;
       return state;
     },
     removeAllStagedAttachmentsInConversation(


### PR DESCRIPTION
Previously, the code simply deduped attachments on file name, using the internal name `image.png` for any pasted image. This effectively made it possible to paste only a single image into a message.

With this patch, we now ignore files called `image.png` when deduping.

Deduping on file name is flawed anyway, because:

1. It's trivial to post multiple identical attachments, so long as each of them has a different file name.

2. It's **not** possible to post different attachments if they happen to have the same base file name (i.e. after the directory component is removed).

So, we're actually getting both false positives and false negatives here.

Fixes oxen-io/session-desktop-temp#410, but introduces a new problem:

When deleting a pasted attachment from a list of such attachments prior to sending, **all** pasted attachments are removed, presumably due to their all having the same internal file name.

It may be better not to dedupe attachments at all, rather than use the crude mechanism of the file name. In that case, the following code would suffice:

```
-    const uniqAttachments = _.uniqBy(allAttachments, m => m.fileName);

-    state.stagedAttachments[conversationKey] = uniqAttachments;
+    state.stagedAttachments[conversationKey] = allAttachments;
```

UPDATE 2023-03-14:

This PR has now been updated to not dedupe attachments at all at staging time.

### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users
