### PR TITLE
When clicking avatar, ask before starting new private conversation.

### DIFF
--- a/ts/components/conversation/message/message-content/MessageAvatar.tsx
+++ b/ts/components/conversation/message/message-content/MessageAvatar.tsx
@@ -65,12 +65,12 @@ export const MessageAvatar = (props: Props) => {
   }
 
   const userName = authorName || authorProfileName || sender;
+  const convoWithSender = getConversationController().get(sender);
 
   const onMessageAvatarClick = useCallback(async () => {
     if (isPublic && !PubKey.hasBlindedPrefix(sender)) {
       // public chat but session id not blinded. disable showing user details if we do not have an active convo with that user.
       // an unactive convo with that user means that we never chatted with that id directyly, but only through a sogs
-      const convoWithSender = getConversationController().get(sender);
       if (!convoWithSender || !convoWithSender.get('active_at')) {
         // for some time, we might still get some unblinded messages, as in message sent unblinded because
         //    * older clients still send unblinded message and those are allowed by sogs if they doesn't enforce blinding
@@ -101,6 +101,20 @@ export const MessageAvatar = (props: Props) => {
         );
 
         privateConvoToOpen = foundRealSessionId || privateConvoToOpen;
+
+	if (foundRealSessionId && convoWithSender.get('active_at')) {
+	  // We know this user's real id and have an active conversation with
+	  // him. Go to it.
+	  await getConversationController()
+	    .get(privateConvoToOpen)
+	    .setOriginConversationID(selectedConvoKey);
+
+	  await openConversationWithMessages({ conversationKey: privateConvoToOpen, messageId: null });
+
+	  return;
+	}
+	// Public and blinded key for this message. Fall through to asking if we
+	// should start a conversation, which will send SOGS blinded message request.
       }
 
       await getConversationController()


### PR DESCRIPTION
Even when we know the user's unblinded Session id, more often than not we just want to see that id, or to see an enlarged rendering of the associated avatar.

![image](https://user-images.githubusercontent.com/749942/219706405-bdba7e78-b1c2-4327-8eb4-c153344034fa.png)

Fixes oxen-io/session-desktop-temp#285.

### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users
