### PR TITLE
Show up to 25 emoji in the recent emoji panel.

### DIFF
--- a/ts/components/conversation/message/message-content/MessageReactBar.tsx
+++ b/ts/components/conversation/message/message-content/MessageReactBar.tsx
@@ -17,12 +17,13 @@ const StyledMessageReactBar = styled.div`
   box-shadow: 0 2px 16px 0 rgba(0, 0, 0, 0.2), 0 0px 20px 0 rgba(0, 0, 0, 0.19);
 
   position: absolute;
-  top: -56px;
+  top: -128px;
   padding: 4px 8px;
   white-space: nowrap;
-  width: 302px;
+  width: 378px;
 
   display: flex;
+  flex-flow: wrap;
   align-items: center;
 
   .session-icon-button {

--- a/ts/types/Reaction.ts
+++ b/ts/types/Reaction.ts
@@ -1,6 +1,6 @@
 import { EmojiSet, PartialI18n } from 'emoji-mart';
 
-export const reactionLimit: number = 6;
+export const reactionLimit: number = 25;
 
 export class RecentReactions {
   public items: Array<string> = [];


### PR DESCRIPTION
6 emoji just isn't enough for a user that makes heavy use of reactions. We have the space and resolution on our monitors, so let's make better use of it.

![image](https://user-images.githubusercontent.com/749942/219706780-2aacd01d-1b84-47cd-94eb-fe031ba7cedd.png)

### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users
