### PR TITLE
Various improvements to the display of unread conversation and unread message counts.

### DIFF
--- a/ts/components/SessionScrollButton.tsx
+++ b/ts/components/SessionScrollButton.tsx
@@ -17,7 +17,7 @@ const SessionScrollButtonDiv = styled.div`
   }
 `;
 
-export const SessionScrollButton = (props: { onClickScrollBottom: () => void }) => {
+export const SessionScrollButton = (props: { onClickScrollBottom: () => void, unreadCount: number }) => {
   const show = useSelector(getShowScrollButton);
 
   return (
@@ -28,6 +28,7 @@ export const SessionScrollButton = (props: { onClickScrollBottom: () => void }) 
         isHidden={!show}
         onClick={props.onClickScrollBottom}
         dataTestId="scroll-to-bottom-button"
+        unreadCount={props.unreadCount}
       />
     </SessionScrollButtonDiv>
   );

--- a/ts/components/conversation/SessionMessagesListContainer.tsx
+++ b/ts/components/conversation/SessionMessagesListContainer.tsx
@@ -144,6 +144,7 @@ class SessionMessagesListContainerInner extends React.Component<Props> {
         <SessionScrollButton
           onClickScrollBottom={this.props.scrollToNow}
           key="scroll-down-button"
+          unreadCount={conversation.unreadCount || 0}
         />
       </StyledMessagesContainer>
     );

--- a/ts/components/icon/SessionIcon.tsx
+++ b/ts/components/icon/SessionIcon.tsx
@@ -14,6 +14,7 @@ export type SessionIconProps = {
   glowStartDelay?: number;
   noScale?: boolean;
   backgroundColor?: string;
+  unreadCount?: number;
 };
 
 const getIconDimensionFromIconSize = (iconSize: SessionIconSize | number) => {

--- a/ts/components/icon/SessionIconButton.tsx
+++ b/ts/components/icon/SessionIconButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { SessionIcon, SessionIconProps } from '../icon';
 import _ from 'lodash';
-import { SessionNotificationCount } from './SessionNotificationCount';
+import { SessionNotificationCount, SessionUnreadCount } from './SessionNotificationCount';
 import styled from 'styled-components';
 
 interface SProps extends SessionIconProps {
@@ -57,6 +57,7 @@ const SessionIconButtonInner = React.forwardRef<HTMLDivElement, SProps>((props, 
     id,
     dataTestId,
     style,
+    unreadCount
   } = props;
   const clickHandler = (e: React.MouseEvent<HTMLDivElement>) => {
     if (props.onClick) {
@@ -90,6 +91,7 @@ const SessionIconButtonInner = React.forwardRef<HTMLDivElement, SProps>((props, 
         iconPadding={iconPadding}
       />
       {Boolean(notificationCount) && <SessionNotificationCount chats={chatCount} count={notificationCount} />}
+      {Boolean(unreadCount) && <SessionUnreadCount count={unreadCount} />}
     </StyledSessionIconButton>
   );
 });

--- a/ts/components/icon/SessionIconButton.tsx
+++ b/ts/components/icon/SessionIconButton.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 
 interface SProps extends SessionIconProps {
   onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
+  chatCount?: number;
   notificationCount?: number;
   isSelected?: boolean;
   isHidden?: boolean;
@@ -43,6 +44,7 @@ const SessionIconButtonInner = React.forwardRef<HTMLDivElement, SProps>((props, 
     iconColor,
     iconRotation,
     isSelected,
+    chatCount,
     notificationCount,
     glowDuration,
     glowStartDelay,
@@ -87,7 +89,7 @@ const SessionIconButtonInner = React.forwardRef<HTMLDivElement, SProps>((props, 
         borderRadius={borderRadius}
         iconPadding={iconPadding}
       />
-      {Boolean(notificationCount) && <SessionNotificationCount count={notificationCount} />}
+      {Boolean(notificationCount) && <SessionNotificationCount chats={chatCount} count={notificationCount} />}
     </StyledSessionIconButton>
   );
 });

--- a/ts/components/icon/SessionNotificationCount.tsx
+++ b/ts/components/icon/SessionNotificationCount.tsx
@@ -10,7 +10,7 @@ const StyledCountContainer = styled.div<{ shouldRender: boolean, unreadCount?: n
   position: absolute;
   font-size: 18px;
   line-height: 1.2;
-  top: ${props => (props.unreadCount ? '29' : '27')}px;
+  top: ${props => (props.unreadCount ? '-6' : '27')}px;
   left: ${props => (props.unreadCount
     ? (15 - props.unreadCount.toString().length * 2).toString()
     : '28'

--- a/ts/components/icon/SessionNotificationCount.tsx
+++ b/ts/components/icon/SessionNotificationCount.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 type Props = {
+  chats?: number;
   count?: number;
 };
 
@@ -11,7 +12,7 @@ const StyledCountContainer = styled.div<{ shouldRender: boolean }>`
   line-height: 1.2;
   top: 27px;
   left: 28px;
-  padding: 1px 1px;
+  padding: 3px 3px;
   opacity: 1;
   display: flex;
   align-items: center;
@@ -32,12 +33,12 @@ const StyledCount = styled.div`
 `;
 
 export const SessionNotificationCount = (props: Props) => {
-  const { count } = props;
+  const { count, chats } = props;
   const shouldRender = Boolean(count && count > 0);
 
   return (
     <StyledCountContainer shouldRender={shouldRender}>
-      <StyledCount>{count}</StyledCount>
+      <StyledCount>{chats} /<br/>{count}</StyledCount>
     </StyledCountContainer>
   );
 };

--- a/ts/components/icon/SessionNotificationCount.tsx
+++ b/ts/components/icon/SessionNotificationCount.tsx
@@ -6,12 +6,15 @@ type Props = {
   count?: number;
 };
 
-const StyledCountContainer = styled.div<{ shouldRender: boolean }>`
+const StyledCountContainer = styled.div<{ shouldRender: boolean, unreadCount?: number }>`
   position: absolute;
   font-size: 18px;
   line-height: 1.2;
-  top: 27px;
-  left: 28px;
+  top: ${props => (props.unreadCount ? '29' : '27')}px;
+  left: ${props => (props.unreadCount
+    ? (15 - props.unreadCount.toString().length * 2).toString()
+    : '28'
+  )}px;
   padding: 3px 3px;
   opacity: 1;
   display: flex;
@@ -39,6 +42,17 @@ export const SessionNotificationCount = (props: Props) => {
   return (
     <StyledCountContainer shouldRender={shouldRender}>
       <StyledCount>{chats} /<br/>{count}</StyledCount>
+    </StyledCountContainer>
+  );
+};
+
+export const SessionUnreadCount = (props: Props) => {
+  const { count } = props;
+  const shouldRender = Boolean(count && count > 0);
+
+  return (
+    <StyledCountContainer shouldRender={shouldRender} unreadCount={count}>
+      <StyledCount>{count}</StyledCount>
     </StyledCountContainer>
   );
 };

--- a/ts/components/icon/SessionNotificationCount.tsx
+++ b/ts/components/icon/SessionNotificationCount.tsx
@@ -11,7 +11,7 @@ const StyledCountContainer = styled.div<{ shouldRender: boolean }>`
   line-height: 1.2;
   top: 27px;
   left: 28px;
-  padding: 1px 4px;
+  padding: 1px 1px;
   opacity: 1;
   display: flex;
   align-items: center;
@@ -33,19 +33,8 @@ const StyledCount = styled.div`
 
 export const SessionNotificationCount = (props: Props) => {
   const { count } = props;
-  const overflow = Boolean(count && count > 99);
   const shouldRender = Boolean(count && count > 0);
 
-  if (overflow) {
-    return (
-      <StyledCountContainer shouldRender={shouldRender}>
-        <StyledCount>
-          {99}
-          <span>+</span>
-        </StyledCount>
-      </StyledCountContainer>
-    );
-  }
   return (
     <StyledCountContainer shouldRender={shouldRender}>
       <StyledCount>{count}</StyledCount>

--- a/ts/components/leftpane/ActionsPanel.tsx
+++ b/ts/components/leftpane/ActionsPanel.tsx
@@ -16,6 +16,7 @@ import useTimeoutFn from 'react-use/lib/useTimeoutFn';
 import { getOurNumber } from '../../state/selectors/user';
 import {
   getOurPrimaryConversation,
+  getUnreadChatCount,
   getUnreadMessageCount,
 } from '../../state/selectors/conversations';
 import { getFocusedSection } from '../../state/selectors/section';
@@ -50,6 +51,7 @@ import { isDarkTheme } from '../../state/selectors/theme';
 
 const Section = (props: { type: SectionType }) => {
   const ourNumber = useSelector(getOurNumber);
+  const unreadChatCount = useSelector(getUnreadChatCount);
   const unreadMessageCount = useSelector(getUnreadMessageCount);
   const dispatch = useDispatch();
   const { type } = props;
@@ -97,6 +99,7 @@ const Section = (props: { type: SectionType }) => {
     );
   }
 
+  const unreadChatsToShow = type === SectionType.Message ? unreadChatCount : undefined;
   const unreadToShow = type === SectionType.Message ? unreadMessageCount : undefined;
 
   switch (type) {
@@ -106,6 +109,7 @@ const Section = (props: { type: SectionType }) => {
           iconSize="medium"
           dataTestId="message-section"
           iconType={'chatBubble'}
+          chatCount={unreadChatsToShow}
           notificationCount={unreadToShow}
           onClick={handleClick}
           isSelected={isSelected}

--- a/ts/components/leftpane/conversation-list-item/HeaderItem.tsx
+++ b/ts/components/leftpane/conversation-list-item/HeaderItem.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 import { Data } from '../../../data/data';
 import { useConversationPropsById, useIsPinned } from '../../../hooks/useParamSelector';
 import { getUsBlindedInThatServer } from '../../../session/apis/open_group_api/sogsv3/knownBlindedkeys';
-import { CONVERSATION } from '../../../session/constants';
 import { UserUtils } from '../../../session/utils';
 import {
   openConversationToSpecificMessage,
@@ -173,7 +172,7 @@ export const ConversationListItemHeaderItem = () => {
     ) : null;
     unreadCountDiv = (
       <p className="module-conversation-list-item__unread-count">
-        {unreadCount > CONVERSATION.MAX_UNREAD_COUNT ? `${CONVERSATION.MAX_UNREAD_COUNT}+` : unreadCount}
+        {unreadCount}
       </p>
     );
   }

--- a/ts/state/selectors/conversations.ts
+++ b/ts/state/selectors/conversations.ts
@@ -339,11 +339,13 @@ export const _getLeftPaneLists = (
   conversations: Array<ReduxConversationType>;
   contacts: Array<ReduxConversationType>;
   unreadCount: number;
+  unreadChats: number;
 } => {
   const conversations: Array<ReduxConversationType> = [];
   const directConversations: Array<ReduxConversationType> = [];
 
   let unreadCount = 0;
+  let unreadChats = 0;
   for (const conversation of sortedConversations) {
     if (
       conversation.activeAt !== undefined &&
@@ -369,6 +371,7 @@ export const _getLeftPaneLists = (
       conversation.currentNotificationSetting !== 'disabled'
     ) {
       unreadCount += conversation.unreadCount;
+      unreadChats += 1;
     }
 
     conversations.push(conversation);
@@ -378,6 +381,7 @@ export const _getLeftPaneLists = (
     conversations,
     contacts: directConversations,
     unreadCount,
+    unreadChats,
   };
 };
 
@@ -504,6 +508,7 @@ export const getDirectContacts = createSelector(
     conversations: Array<ReduxConversationType>;
     contacts: Array<ReduxConversationType>;
     unreadCount: number;
+    unreadChats: number;
   }) => state.contacts
 );
 
@@ -541,6 +546,10 @@ export const getDirectContactsByName = createSelector(
     return [...extractedContactsWithDisplayName, ...extractedContactsNoDisplayName];
   }
 );
+
+export const getUnreadChatCount = createSelector(getLeftPaneLists, (state): number => {
+  return state.unreadChats;
+});
 
 export const getUnreadMessageCount = createSelector(getLeftPaneLists, (state): number => {
   return state.unreadCount;

--- a/ts/state/selectors/conversations.ts
+++ b/ts/state/selectors/conversations.ts
@@ -364,7 +364,6 @@ export const _getLeftPaneLists = (
     }
 
     if (
-      unreadCount < 100 &&
       conversation.unreadCount &&
       conversation.unreadCount > 0 &&
       conversation.currentNotificationSetting !== 'disabled'


### PR DESCRIPTION
### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

Various fixes for tracking the unread message count:

* There's now no cap on the number of unread messages reported. Arbitrarily imposing an upper bound on this doesn't seem useful to me, so I have removed it.
* For the same reason, there's now also no cap on the number of unread conversations reported.
* The number of unread conversations is now reported with the total number of unread messages across all conversations.
* The scroll-to-bottom button is now overlaid with the number of messages still unread in the currently selected conversation.

If you don't want all of these changes, just pick and choose the parts you want.

It's getting harder for me over time to submit modular pull-requests, because my own fork is steadily diverging from upstream and the features I add are slowly introducing dependencies between pull-requests, some of which have already been rejected upstream.

The dual unread convo/unread message count from the action panel:

![image](https://user-images.githubusercontent.com/749942/223975603-6766a63f-4bed-4c1a-9302-834fd61dcbd4.png)

Examples of the unread message count atop the scroll-to-bottom. The position auto-adjusts, based on the width (i.e. number of digits) of the count:

![chevron10](https://user-images.githubusercontent.com/749942/223975985-a1add072-1c21-4412-ad2a-b45759332c10.png)![chevron9](https://user-images.githubusercontent.com/749942/223975988-fb815d7e-3822-46e9-9941-23ef8ae6e40b.png)![chevron8](https://user-images.githubusercontent.com/749942/223975991-bf39b23e-544b-42e9-bb99-a015eda2b721.png)![chevron7](https://user-images.githubusercontent.com/749942/223975992-db2ea145-e89f-424c-824f-b4780e396ec3.png)![chevron6](https://user-images.githubusercontent.com/749942/223975996-e662c579-166b-43fa-91f8-54c9ef2adb6a.png)
