### PR TITLE
Enable FTS5 full-text searches.

### DIFF
--- a/ts/util/cleanSearchTerm.ts
+++ b/ts/util/cleanSearchTerm.ts
@@ -1,22 +1,4 @@
 export function cleanSearchTerm(searchTerm: string) {
-  const lowercase = searchTerm.toLowerCase();
-  const withoutSpecialCharacters = lowercase.replace(/([!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~])/g, ' ');
-  const whiteSpaceNormalized = withoutSpecialCharacters.replace(/\s+/g, ' ');
-  const byToken = whiteSpaceNormalized.split(' ');
-  // be aware that a user typing Note To Self will have an issue when the `not` part of it is typed as the not word is reserved
-  const withoutSpecialTokens = byToken.filter(
-    token =>
-      token &&
-      token !== 'and' &&
-      token !== 'or' &&
-      token !== 'not' &&
-      token !== ')' &&
-      token !== '(' &&
-      token !== '+' &&
-      token !== ',' &&
-      token !== 'near'
-  );
-  const withWildcards = withoutSpecialTokens.map(token => `${token}*`);
-
-  return withWildcards.join(' ').trim();
+  const whiteSpaceNormalized = searchTerm.replace(/\s+/g, ' ');
+  return whiteSpaceNormalized.trim();
 }


### PR DESCRIPTION
Session uses SQLite FTS5 tables that allow full-text searching, but also includes code that renders this type of advanced search inoperable.

This patch restores the functionality, allowing the use of prefix queries (e.g. 'lin*'), Boolean operators (AND, OR and NOT), initial token queries (e.g. '^Linux') and NEAR groups.

Operators must appear in upper case, so 'AND' is a Boolean operator, but 'and' is a search for the literal word 'and'.

Note that whitespace implies a Boolean AND, so 'linux AND applications' is syntactically equivalent to 'linux applications', either of which searches for any message containing both words in any order, and not necessarily appearing contiguously.

To search for the contiguous expression 'linux applications', surround it with double quotes: '"linux applications"'.

Parentheses may be used to change operator precedence and build complex expressions.

The BNF for the FTS query syntax is this:

```
<phrase>    := string [*]
<phrase>    := <phrase> + <phrase>
<neargroup> := NEAR ( <phrase> <phrase> ... [, N] )
<query>     := [ [-] <colspec> :] [^] <phrase>
<query>     := [ [-] <colspec> :] <neargroup>
<query>     := [ [-] <colspec> :] ( <query> )
<query>     := <query> AND <query>
<query>     := <query> OR <query>
<query>     := <query> NOT <query>
<colspec>   := colname
<colspec>   := { colname1 colname2 ... }
```

For more information, please see:

https://www.sqlite.org/fts5.html#full_text_query_syntax

### Contributor checklist:

- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/oxen-io/session-desktop/tree/clearnet) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/oxen-io/session-desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users
