### PR TITLE
Message sending box RTL support

### DIFF
--- a/ts/components/SessionMainPanel.tsx
+++ b/ts/components/SessionMainPanel.tsx
@@ -5,12 +5,14 @@ import { getFocusedSettingsSection } from '../state/selectors/section';
 
 import { SmartSessionConversation } from '../state/smart/SessionConversation';
 import { SessionSettingsView } from './settings/SessionSettings';
+import { useHTMLDirection } from '../util/i18n';
 
 const FilteredSettingsView = SessionSettingsView as any;
 
 export const SessionMainPanel = () => {
   const focusedSettingsSection = useSelector(getFocusedSettingsSection);
   const isSettingsView = focusedSettingsSection !== undefined;
+  const htmlDirection = useHTMLDirection();
 
   // even if it looks like this does nothing, this does update the redux store.
   useAppIsFocused();
@@ -20,7 +22,7 @@ export const SessionMainPanel = () => {
   }
   return (
     <div className="session-conversation">
-      <SmartSessionConversation />
+      <SmartSessionConversation htmlDirection={htmlDirection} />
     </div>
   );
 };

--- a/ts/components/basic/Flex.tsx
+++ b/ts/components/basic/Flex.tsx
@@ -6,7 +6,7 @@ export interface FlexProps {
   container?: boolean;
   dataTestId?: string;
   /****** Container Props ********/
-  flexDirection?: 'row' | 'column';
+  flexDirection?: 'row' | 'row-reverse' | 'column' | 'column-reverse';
   justifyContent?:
     | 'flex-start'
     | 'flex-end'

--- a/ts/components/basic/Flex.tsx
+++ b/ts/components/basic/Flex.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { HTMLDirection } from '../../util/i18n';
 
 export interface FlexProps {
   children?: any;
@@ -36,6 +37,8 @@ export interface FlexProps {
   maxWidth?: string;
   minWidth?: string;
   maxHeight?: string;
+  /****** RTL support ********/
+  dir?: HTMLDirection;
 }
 
 export const Flex = styled.div<FlexProps>`
@@ -53,4 +56,5 @@ export const Flex = styled.div<FlexProps>`
   height: ${props => props.height || 'auto'};
   max-width: ${props => props.maxWidth || 'none'};
   min-width: ${props => props.minWidth || 'none'};
+  dir: ${props => props.dir || undefined};
 `;

--- a/ts/components/conversation/SessionConversation.tsx
+++ b/ts/components/conversation/SessionConversation.tsx
@@ -57,6 +57,7 @@ import { MessageDetail } from './message/message-item/MessageDetail';
 
 import styled from 'styled-components';
 import { SessionSpinner } from '../basic/SessionSpinner';
+import { HTMLDirection } from '../../util/i18n';
 // tslint:disable: jsx-curly-spacing
 
 interface State {
@@ -76,6 +77,7 @@ interface Props {
   showMessageDetails: boolean;
   isRightPanelShowing: boolean;
   hasOngoingCallWithFocusedConvo: boolean;
+  htmlDirection: HTMLDirection;
 
   // lightbox options
   lightBoxOptions?: LightBoxOptions;
@@ -290,6 +292,7 @@ export class SessionConversation extends React.Component<Props, State> {
                 sendMessage={this.sendMessageFn}
                 stagedAttachments={this.props.stagedAttachments}
                 onChoseAttachments={this.onChoseAttachments}
+                htmlDirection={this.props.htmlDirection}
               />
             </div>
             <div

--- a/ts/components/conversation/SessionEmojiPanel.tsx
+++ b/ts/components/conversation/SessionEmojiPanel.tsx
@@ -16,8 +16,10 @@ import {
 import { hexColorToRGB } from '../../util/hexColorToRGB';
 import { getPrimaryColor } from '../../state/selectors/primaryColor';
 import { i18nEmojiData } from '../../util/emoji';
+import { getWritingDirection } from '../../state/selectors/user';
 
 export const StyledEmojiPanel = styled.div<{
+  dir: string;
   isModal: boolean;
   primaryColor: PrimaryColorStateType;
   theme: ThemeStateType;
@@ -68,7 +70,7 @@ export const StyledEmojiPanel = styled.div<{
         content: '';
         position: absolute;
         top: calc(100% - 40px);
-        left: calc(100% - 79px);
+        left: ${props.dir === 'rtl' ? '75px' : 'calc(100% - 106px)'};
         width: 22px;
         height: 22px;
         transform: rotate(45deg);
@@ -102,6 +104,7 @@ export const SessionEmojiPanel = forwardRef<HTMLDivElement, Props>((props: Props
   const primaryColor = useSelector(getPrimaryColor);
   const theme = useSelector(getTheme);
   const isDarkMode = useSelector(isDarkTheme);
+  const writingDirection = useSelector(getWritingDirection);
 
   let panelBackgroundRGB = hexColorToRGB(THEMES.CLASSIC_DARK.COLOR1);
   let panelTextRGB = hexColorToRGB(THEMES.CLASSIC_DARK.COLOR6);
@@ -134,6 +137,7 @@ export const SessionEmojiPanel = forwardRef<HTMLDivElement, Props>((props: Props
       theme={theme}
       panelBackgroundRGB={panelBackgroundRGB}
       panelTextRGB={panelTextRGB}
+      dir={writingDirection}
       className={classNames(show && 'show')}
       ref={ref}
     >

--- a/ts/components/conversation/SessionEmojiPanel.tsx
+++ b/ts/components/conversation/SessionEmojiPanel.tsx
@@ -16,10 +16,8 @@ import {
 import { hexColorToRGB } from '../../util/hexColorToRGB';
 import { getPrimaryColor } from '../../state/selectors/primaryColor';
 import { i18nEmojiData } from '../../util/emoji';
-import { getWritingDirection } from '../../state/selectors/user';
 
 export const StyledEmojiPanel = styled.div<{
-  dir: string;
   isModal: boolean;
   primaryColor: PrimaryColorStateType;
   theme: ThemeStateType;
@@ -70,7 +68,7 @@ export const StyledEmojiPanel = styled.div<{
         content: '';
         position: absolute;
         top: calc(100% - 40px);
-        left: ${props.dir === 'rtl' ? '75px' : 'calc(100% - 106px)'};
+        left: calc(100% - 106px);
         width: 22px;
         height: 22px;
         transform: rotate(45deg);
@@ -79,6 +77,10 @@ export const StyledEmojiPanel = styled.div<{
         border: 0.7px solid var(--border-color);
         clip-path: polygon(100% 100%, 7.2px 100%, 100% 7.2px);
         ${props.panelBackgroundRGB && `background-color: rgb(${props.panelBackgroundRGB})`};
+
+        [dir='rtl'] & {
+          left: 75px;
+        }
       }
     `};
   }
@@ -104,7 +106,6 @@ export const SessionEmojiPanel = forwardRef<HTMLDivElement, Props>((props: Props
   const primaryColor = useSelector(getPrimaryColor);
   const theme = useSelector(getTheme);
   const isDarkMode = useSelector(isDarkTheme);
-  const writingDirection = useSelector(getWritingDirection);
 
   let panelBackgroundRGB = hexColorToRGB(THEMES.CLASSIC_DARK.COLOR1);
   let panelTextRGB = hexColorToRGB(THEMES.CLASSIC_DARK.COLOR6);
@@ -137,7 +138,6 @@ export const SessionEmojiPanel = forwardRef<HTMLDivElement, Props>((props: Props
       theme={theme}
       panelBackgroundRGB={panelBackgroundRGB}
       panelTextRGB={panelTextRGB}
-      dir={writingDirection}
       className={classNames(show && 'show')}
       ref={ref}
     >

--- a/ts/components/conversation/composition/CompositionBox.tsx
+++ b/ts/components/conversation/composition/CompositionBox.tsx
@@ -117,7 +117,7 @@ interface State {
   htmlDirection?: HTMLDirection;
 }
 
-const sendMessageStyle = (dir: HTMLDirection) => {
+const sendMessageStyle = (dir?: HTMLDirection) => {
   return {
     control: {
       wordBreak: 'break-all',
@@ -497,7 +497,7 @@ class CompositionBoxInner extends React.Component<Props, State> {
     const { typingEnabled } = this.props;
     const neverMatchingRegex = /($a)/;
 
-    const style = sendMessageStyle(htmlDirection || 'ltr');
+    const style = sendMessageStyle(htmlDirection);
 
     return (
       <MentionsInput

--- a/ts/components/conversation/composition/CompositionBox.tsx
+++ b/ts/components/conversation/composition/CompositionBox.tsx
@@ -221,7 +221,7 @@ const StyledSendMessageInput = styled.div<{ dir: string }>`
   flex-grow: 1;
   min-height: var(--composition-container-height);
   padding: var(--margins-xs) 0;
-  ${props => (props.dir = 'rtl' && 'margin-right: var(--margins-sm);')}
+  ${props => props.dir === 'rtl' && 'margin-inline-start: var(--margins-sm);'}
   z-index: 1;
   background-color: inherit;
 

--- a/ts/components/conversation/composition/CompositionBox.tsx
+++ b/ts/components/conversation/composition/CompositionBox.tsx
@@ -57,7 +57,7 @@ import {
   getSelectedConversationKey,
 } from '../../../state/selectors/selectedConversation';
 import { SettingsKey } from '../../../data/settings-key';
-import { isRtlBody } from '../../menu/Menu';
+import { getHTMLDirection } from '../../../util/i18n';
 
 export interface ReplyingToMessageProps {
   convoId: string;
@@ -411,13 +411,13 @@ class CompositionBoxInner extends React.Component<Props, State> {
     const { showEmojiPanel } = this.state;
     const { typingEnabled } = this.props;
 
-    const rtl = isRtlBody();
-    const writingDirection = rtl ? 'rtl' : 'ltr';
+    const htmlDirection = getHTMLDirection();
 
     return (
       <Flex
+        dir={htmlDirection}
         container={true}
-        flexDirection={rtl ? 'row-reverse' : 'row'}
+        flexDirection={'row'}
         alignItems={'center'}
         width={'100%'}
       >
@@ -436,14 +436,14 @@ class CompositionBoxInner extends React.Component<Props, State> {
 
         <StyledSendMessageInput
           role="main"
-          dir={writingDirection}
+          dir={htmlDirection}
           onClick={this.focusCompositionBox} // used to focus on the textarea when clicking in its container
           ref={el => {
             this.container = el;
           }}
           data-testid="message-input"
         >
-          {this.renderTextArea(writingDirection)}
+          {this.renderTextArea(htmlDirection)}
         </StyledSendMessageInput>
 
         {typingEnabled && (
@@ -452,7 +452,7 @@ class CompositionBoxInner extends React.Component<Props, State> {
         <SendMessageButton onClick={this.onSendMessage} />
 
         {typingEnabled && showEmojiPanel && (
-          <StyledEmojiPanelContainer role="button" dir={writingDirection}>
+          <StyledEmojiPanelContainer role="button" dir={htmlDirection}>
             <SessionEmojiPanel
               ref={this.emojiPanel}
               show={showEmojiPanel}

--- a/ts/components/conversation/composition/CompositionBox.tsx
+++ b/ts/components/conversation/composition/CompositionBox.tsx
@@ -57,7 +57,7 @@ import {
   getSelectedConversationKey,
 } from '../../../state/selectors/selectedConversation';
 import { SettingsKey } from '../../../data/settings-key';
-import { getHTMLDirection, HTMLDirection } from '../../../util/i18n';
+import { HTMLDirection } from '../../../util/i18n';
 
 export interface ReplyingToMessageProps {
   convoId: string;
@@ -105,6 +105,7 @@ interface Props {
   quotedMessageProps?: ReplyingToMessageProps;
   stagedAttachments: Array<StagedAttachmentType>;
   onChoseAttachments: (newAttachments: Array<File>) => void;
+  htmlDirection: HTMLDirection;
 }
 
 interface State {
@@ -114,7 +115,6 @@ interface State {
   ignoredLink?: string; // set the ignored url when users closed the link preview
   stagedLinkPreview?: StagedLinkPreviewData;
   showCaptionEditor?: AttachmentType;
-  htmlDirection?: HTMLDirection;
 }
 
 const sendMessageStyle = (dir?: HTMLDirection) => {
@@ -149,7 +149,6 @@ const getDefaultState = (newConvoId?: string) => {
     ignoredLink: undefined,
     stagedLinkPreview: undefined,
     showCaptionEditor: undefined,
-    htmlDirection: getHTMLDirection(),
   };
 };
 
@@ -418,7 +417,7 @@ class CompositionBoxInner extends React.Component<Props, State> {
 
     return (
       <Flex
-        dir={this.state.htmlDirection}
+        dir={this.props.htmlDirection}
         container={true}
         flexDirection={'row'}
         alignItems={'center'}
@@ -439,7 +438,7 @@ class CompositionBoxInner extends React.Component<Props, State> {
 
         <StyledSendMessageInput
           role="main"
-          dir={this.state.htmlDirection}
+          dir={this.props.htmlDirection}
           onClick={this.focusCompositionBox} // used to focus on the textarea when clicking in its container
           ref={el => {
             this.container = el;
@@ -455,7 +454,7 @@ class CompositionBoxInner extends React.Component<Props, State> {
         <SendMessageButton onClick={this.onSendMessage} />
 
         {typingEnabled && showEmojiPanel && (
-          <StyledEmojiPanelContainer role="button" dir={this.state.htmlDirection}>
+          <StyledEmojiPanelContainer role="button" dir={this.props.htmlDirection}>
             <SessionEmojiPanel
               ref={this.emojiPanel}
               show={showEmojiPanel}
@@ -470,7 +469,8 @@ class CompositionBoxInner extends React.Component<Props, State> {
 
   private renderTextArea() {
     const { i18n } = window;
-    const { draft, htmlDirection } = this.state;
+    const { draft } = this.state;
+    const { htmlDirection } = this.props;
 
     if (!this.props.selectedConversation) {
       return null;

--- a/ts/components/conversation/composition/EmojiQuickResult.tsx
+++ b/ts/components/conversation/composition/EmojiQuickResult.tsx
@@ -8,6 +8,7 @@ import { searchSync } from '../../../util/emoji.js';
 const EmojiQuickResult = styled.span`
   display: flex;
   align-items: center;
+  min-width: 250px;
   width: 100%;
   padding-inline-end: 20px;
   padding-inline-start: 10px;

--- a/ts/components/conversation/composition/UserMentions.tsx
+++ b/ts/components/conversation/composition/UserMentions.tsx
@@ -1,28 +1,40 @@
 import React from 'react';
 import { SuggestionDataItem } from 'react-mentions';
 import { MemberListItem } from '../../MemberListItem';
+import { HTMLDirection } from '../../../util/i18n';
 
-export const styleForCompositionBoxSuggestions = {
-  suggestions: {
-    list: {
-      fontSize: 14,
-      boxShadow: 'var(--suggestions-shadow)',
-      backgroundColor: 'var(--suggestions-background-color)',
-      color: 'var(--suggestions-text-color)',
-    },
-    item: {
-      height: '100%',
-      paddingTop: '5px',
-      paddingBottom: '5px',
-      backgroundColor: 'var(--suggestions-background-color)',
-      color: 'var(--suggestions-text-color)',
-      transition: '0.25s',
+const listRTLStyle = { position: 'absolute', bottom: '0px', right: '100%' };
 
-      '&focused': {
-        backgroundColor: 'var(--suggestions-background-hover-color)',
+export const styleForCompositionBoxSuggestions = (dir: HTMLDirection) => {
+  const styles = {
+    suggestions: {
+      list: {
+        fontSize: 14,
+        boxShadow: 'var(--suggestions-shadow)',
+        backgroundColor: 'var(--suggestions-background-color)',
+        color: 'var(--suggestions-text-color)',
+        dir,
+      },
+      item: {
+        height: '100%',
+        paddingTop: '5px',
+        paddingBottom: '5px',
+        backgroundColor: 'var(--suggestions-background-color)',
+        color: 'var(--suggestions-text-color)',
+        transition: '0.25s',
+
+        '&focused': {
+          backgroundColor: 'var(--suggestions-background-hover-color)',
+        },
       },
     },
-  },
+  };
+
+  if (dir === 'rtl') {
+    styles.suggestions.list = { ...styles.suggestions.list, ...listRTLStyle };
+  }
+
+  return styles;
 };
 
 export const renderUserMentionRow = (suggestion: SuggestionDataItem) => {

--- a/ts/components/conversation/composition/UserMentions.tsx
+++ b/ts/components/conversation/composition/UserMentions.tsx
@@ -5,7 +5,7 @@ import { HTMLDirection } from '../../../util/i18n';
 
 const listRTLStyle = { position: 'absolute', bottom: '0px', right: '100%' };
 
-export const styleForCompositionBoxSuggestions = (dir: HTMLDirection) => {
+export const styleForCompositionBoxSuggestions = (dir: HTMLDirection = 'ltr') => {
   const styles = {
     suggestions: {
       list: {

--- a/ts/components/menu/Menu.tsx
+++ b/ts/components/menu/Menu.tsx
@@ -373,12 +373,6 @@ export const MarkAllReadMenuItem = (): JSX.Element | null => {
   }
 };
 
-export function isRtlBody(): boolean {
-  const body = document.getElementsByTagName('body').item(0);
-
-  return body?.classList.contains('rtl') || false;
-}
-
 export const BlockMenuItem = (): JSX.Element | null => {
   const convoId = useConvoIdFromContext();
   const isMe = useIsMe(convoId);
@@ -577,7 +571,7 @@ export const NotificationForConvoMenuItem = (): JSX.Element | null => {
     return null;
   }
 
-  // const isRtlMode = isRtlBody();'
+  // const isRtlMode = isRtlBody();
 
   // exclude mentions_only settings for private chats as this does not make much sense
   const notificationForConvoOptions = ConversationNotificationSetting.filter(n =>

--- a/ts/mains/main_node.ts
+++ b/ts/mains/main_node.ts
@@ -745,8 +745,9 @@ app.on('ready', async () => {
   assertLogger().info('app ready');
   assertLogger().info(`starting version ${packageJson.version}`);
   if (!locale) {
-    const appLocale = app.getLocale() || 'en';
+    const appLocale = process.env.LANGUAGE || app.getLocale() || 'en';
     locale = loadLocale({ appLocale, logger });
+    assertLogger().info(`locale is ${appLocale}`);
   }
 
   const key = getDefaultSQLKey();

--- a/ts/state/selectors/user.ts
+++ b/ts/state/selectors/user.ts
@@ -4,7 +4,6 @@ import { LocalizerType } from '../../types/Util';
 
 import { StateType } from '../reducer';
 import { UserStateType } from '../ducks/user';
-import { HTMLDirection, isRtlBody } from '../../util/i18n';
 
 export const getUser = (state: StateType): UserStateType => state.user;
 
@@ -14,8 +13,3 @@ export const getOurNumber = createSelector(
 );
 
 export const getIntl = createSelector(getUser, (): LocalizerType => window.i18n);
-
-export const getHTMLDirection = createSelector(
-  getUser,
-  (): HTMLDirection => (isRtlBody() ? 'rtl' : 'ltr')
-);

--- a/ts/state/selectors/user.ts
+++ b/ts/state/selectors/user.ts
@@ -4,6 +4,7 @@ import { LocalizerType } from '../../types/Util';
 
 import { StateType } from '../reducer';
 import { UserStateType } from '../ducks/user';
+import { isRtlBody } from '../../components/menu/Menu';
 
 export const getUser = (state: StateType): UserStateType => state.user;
 
@@ -13,3 +14,7 @@ export const getOurNumber = createSelector(
 );
 
 export const getIntl = createSelector(getUser, (): LocalizerType => window.i18n);
+
+export const getWritingDirection = createSelector(getUser, (): string =>
+  isRtlBody() ? 'rtl' : 'ltr'
+);

--- a/ts/state/selectors/user.ts
+++ b/ts/state/selectors/user.ts
@@ -4,7 +4,7 @@ import { LocalizerType } from '../../types/Util';
 
 import { StateType } from '../reducer';
 import { UserStateType } from '../ducks/user';
-import { isRtlBody } from '../../components/menu/Menu';
+import { HTMLDirection, getHTMLDirection } from '../../util/i18n';
 
 export const getUser = (state: StateType): UserStateType => state.user;
 
@@ -15,6 +15,4 @@ export const getOurNumber = createSelector(
 
 export const getIntl = createSelector(getUser, (): LocalizerType => window.i18n);
 
-export const getWritingDirection = createSelector(getUser, (): string =>
-  isRtlBody() ? 'rtl' : 'ltr'
-);
+export const getWritingDirection = createSelector(getUser, (): HTMLDirection => getHTMLDirection());

--- a/ts/state/selectors/user.ts
+++ b/ts/state/selectors/user.ts
@@ -4,7 +4,6 @@ import { LocalizerType } from '../../types/Util';
 
 import { StateType } from '../reducer';
 import { UserStateType } from '../ducks/user';
-import { HTMLDirection, getHTMLDirection } from '../../util/i18n';
 
 export const getUser = (state: StateType): UserStateType => state.user;
 
@@ -14,5 +13,3 @@ export const getOurNumber = createSelector(
 );
 
 export const getIntl = createSelector(getUser, (): LocalizerType => window.i18n);
-
-export const getWritingDirection = createSelector(getUser, (): HTMLDirection => getHTMLDirection());

--- a/ts/state/selectors/user.ts
+++ b/ts/state/selectors/user.ts
@@ -4,6 +4,7 @@ import { LocalizerType } from '../../types/Util';
 
 import { StateType } from '../reducer';
 import { UserStateType } from '../ducks/user';
+import { HTMLDirection, isRtlBody } from '../../util/i18n';
 
 export const getUser = (state: StateType): UserStateType => state.user;
 
@@ -13,3 +14,8 @@ export const getOurNumber = createSelector(
 );
 
 export const getIntl = createSelector(getUser, (): LocalizerType => window.i18n);
+
+export const getHTMLDirection = createSelector(
+  getUser,
+  (): HTMLDirection => (isRtlBody() ? 'rtl' : 'ltr')
+);

--- a/ts/state/smart/SessionConversation.ts
+++ b/ts/state/smart/SessionConversation.ts
@@ -17,7 +17,7 @@ import {
 } from '../selectors/selectedConversation';
 import { getStagedAttachmentsForCurrentConversation } from '../selectors/stagedAttachments';
 import { getTheme } from '../selectors/theme';
-import { getOurNumber } from '../selectors/user';
+import { getHTMLDirection, getOurNumber } from '../selectors/user';
 
 const mapStateToProps = (state: StateType) => {
   return {
@@ -33,6 +33,7 @@ const mapStateToProps = (state: StateType) => {
     stagedAttachments: getStagedAttachmentsForCurrentConversation(state),
     hasOngoingCallWithFocusedConvo: getHasOngoingCallWithFocusedConvo(state),
     isSelectedConvoInitialLoadingInProgress: getIsSelectedConvoInitialLoadingInProgress(state),
+    htmlDirection: getHTMLDirection(state),
   };
 };
 

--- a/ts/state/smart/SessionConversation.ts
+++ b/ts/state/smart/SessionConversation.ts
@@ -17,9 +17,14 @@ import {
 } from '../selectors/selectedConversation';
 import { getStagedAttachmentsForCurrentConversation } from '../selectors/stagedAttachments';
 import { getTheme } from '../selectors/theme';
-import { getHTMLDirection, getOurNumber } from '../selectors/user';
+import { getOurNumber } from '../selectors/user';
+import { HTMLDirection } from '../../util/i18n';
 
-const mapStateToProps = (state: StateType) => {
+type SmartSessionConversationOwnProps = {
+  htmlDirection: HTMLDirection;
+};
+
+const mapStateToProps = (state: StateType, ownProps: SmartSessionConversationOwnProps) => {
   return {
     selectedConversation: getSelectedConversation(state),
     selectedConversationKey: getSelectedConversationKey(state),
@@ -33,7 +38,7 @@ const mapStateToProps = (state: StateType) => {
     stagedAttachments: getStagedAttachmentsForCurrentConversation(state),
     hasOngoingCallWithFocusedConvo: getHasOngoingCallWithFocusedConvo(state),
     isSelectedConvoInitialLoadingInProgress: getIsSelectedConvoInitialLoadingInProgress(state),
-    htmlDirection: getHTMLDirection(state),
+    htmlDirection: ownProps.htmlDirection,
   };
 };
 

--- a/ts/util/i18n.ts
+++ b/ts/util/i18n.ts
@@ -73,7 +73,3 @@ export function isRtlBody(): boolean {
 
   return body?.classList.contains('rtl') || false;
 }
-
-export function getHTMLDirection(): HTMLDirection {
-  return isRtlBody() ? 'rtl' : 'ltr';
-}

--- a/ts/util/i18n.ts
+++ b/ts/util/i18n.ts
@@ -63,3 +63,17 @@ export const loadEmojiPanelI18n = async () => {
     }
   }
 };
+
+// RTL Support
+
+export type HTMLDirection = 'ltr' | 'rtl';
+
+export function isRtlBody(): boolean {
+  const body = document.getElementsByTagName('body').item(0);
+
+  return body?.classList.contains('rtl') || false;
+}
+
+export function getHTMLDirection(): HTMLDirection {
+  return isRtlBody() ? 'rtl' : 'ltr';
+}

--- a/ts/util/i18n.ts
+++ b/ts/util/i18n.ts
@@ -73,3 +73,5 @@ export function isRtlBody(): boolean {
 
   return body?.classList.contains('rtl') || false;
 }
+
+export const useHTMLDirection = (): HTMLDirection => (isRtlBody() ? 'rtl' : 'ltr');


### PR DESCRIPTION
Fixes https://github.com/oxen-io/session-desktop-temp/issues/345

- Composition Input buttons are now RTL when RTL is set.
- Cleaned up RTL document checking and created a quick function to check the RTL state of the app
- The user mentions and emoji quick results now support RTL and the popup appears in the correct position relative to the cursor.
- When you pass the `LANGUAGE` flag it will also set the UI language not just the spellchecker. Originally the UI language could only be set via the `--lang` flag.
- The Emoji Panel is now correctly positioned when clicking the button in an RTL state
- Added RTL support to the Flex component

**NOTE** Needs more testing and feedback from RTL users which can only happen once we merge user config into clearnet