### PR TITLE
Quote fixes

### DIFF
--- a/ts/components/basic/SessionDropdown.tsx
+++ b/ts/components/basic/SessionDropdown.tsx
@@ -17,15 +17,16 @@ type Props = {
     active?: boolean;
     onClick?: any;
   }>;
+  dataTestId?: string;
 };
 
 export const SessionDropdown = (props: Props) => {
-  const { label, options } = props;
+  const { label, options, dataTestId } = props;
   const [expanded, setExpanded] = useState(!!props.expanded);
   const chevronOrientation = expanded ? 180 : 0;
 
   return (
-    <div className="session-dropdown">
+    <div className="session-dropdown" data-testid={dataTestId}>
       <div
         className="session-dropdown__label"
         onClick={() => {
@@ -43,6 +44,7 @@ export const SessionDropdown = (props: Props) => {
             return (
               <SessionDropdownItem
                 key={item.content}
+                dataTestId={`dropdownitem-${item.content.replace(' ', '-')}`}
                 content={item.content}
                 icon={item.icon}
                 type={item.type}

--- a/ts/components/basic/SessionDropdownItem.tsx
+++ b/ts/components/basic/SessionDropdownItem.tsx
@@ -13,6 +13,7 @@ type Props = {
   icon: SessionIconType | null;
   active: boolean;
   onClick: any;
+  dataTestId?: string;
 };
 
 export const SessionDropdownItem = (props: Props) => {
@@ -23,7 +24,7 @@ export const SessionDropdownItem = (props: Props) => {
     }
   };
 
-  const { content, type, icon, active } = props;
+  const { content, type, icon, active, dataTestId } = props;
 
   return (
     <div
@@ -34,6 +35,7 @@ export const SessionDropdownItem = (props: Props) => {
       )}
       role="button"
       onClick={clickHandler}
+      data-testid={dataTestId}
     >
       {icon ? <SessionIcon iconType={icon} iconSize="small" /> : ''}
       <div className="item-content">{content}</div>

--- a/ts/components/conversation/SessionRightPanel.tsx
+++ b/ts/components/conversation/SessionRightPanel.tsx
@@ -354,6 +354,7 @@ export const SessionRightPanelWithDetails = () => {
         <SessionDropdown
           label={window.i18n('disappearingMessages')}
           options={disappearingMessagesOptions}
+          dataTestId="disappearing-messages-dropdown"
         />
       )}
 

--- a/ts/components/conversation/message/message-content/quote/QuoteAuthor.tsx
+++ b/ts/components/conversation/message/message-content/quote/QuoteAuthor.tsx
@@ -29,7 +29,7 @@ export const QuoteAuthor = (props: QuoteAuthorProps) => {
   const { author, isIncoming } = props;
 
   const isPublic = useSelectedIsPublic();
-  const authorName = useQuoteAuthorName(author);
+  const { authorName, isMe } = useQuoteAuthorName(author);
 
   if (!author || !authorName) {
     return null;
@@ -41,7 +41,7 @@ export const QuoteAuthor = (props: QuoteAuthorProps) => {
         pubkey={PubKey.shorten(author)}
         name={authorName}
         compact={true}
-        shouldShowPubkey={Boolean(authorName && isPublic)}
+        shouldShowPubkey={Boolean(authorName && !isMe && isPublic)}
       />
     </StyledQuoteAuthor>
   );

--- a/ts/hooks/useParamSelector.ts
+++ b/ts/hooks/useParamSelector.ts
@@ -264,11 +264,17 @@ export function useIsTyping(conversationId?: string): boolean {
   return useConversationPropsById(conversationId)?.isTyping || false;
 }
 
-export function useQuoteAuthorName(authorId?: string) {
+export function useQuoteAuthorName(
+  authorId?: string
+): { authorName: string | undefined; isMe: boolean } {
   const convoProps = useConversationPropsById(authorId);
-  return authorId && isUsAnySogsFromCache(authorId)
+
+  const isMe = Boolean(authorId && isUsAnySogsFromCache(authorId));
+  const authorName = isMe
     ? window.i18n('you')
     : convoProps?.nickname || convoProps?.isPrivate
     ? convoProps?.displayNameInProfile
     : undefined;
+
+  return { authorName, isMe };
 }

--- a/ts/receiver/attachments.ts
+++ b/ts/receiver/attachments.ts
@@ -218,27 +218,27 @@ async function processQuoteAttachments(
   const isOpenGroupV2 = convo.isOpenGroupV2();
   const openGroupV2Details = (isOpenGroupV2 && convo.toOpenGroupV2()) || undefined;
 
-  quote.attachments = await Promise.all(
-    quote.attachments.map(async (item: any, index: any) => {
-      // If we already have a path, then we copied this image from the quoted
-      //    message and we don't need to download the attachment.
-      if (!item.thumbnail || item.thumbnail.path) {
-        return item;
-      }
+  for (let index = 0; index < quote.attachments.length - 1; index++) {
+    // If we already have a path, then we copied this image from the quoted
+    // message and we don't need to download the attachment.
+    const attachment = quote.attachments[index];
 
-      addedCount += 1;
+    if (!attachment.thumbnail || attachment.thumbnail.path) {
+      continue;
+    }
 
-      const thumbnail = await AttachmentDownloads.addJob(item.thumbnail, {
-        messageId: message.id,
-        type: 'quote',
-        index,
-        isOpenGroupV2,
-        openGroupV2Details,
-      });
+    addedCount += 1;
 
-      return { ...item, thumbnail };
-    })
-  );
+    const thumbnail = await AttachmentDownloads.addJob(attachment.thumbnail, {
+      messageId: message.id,
+      type: 'quote',
+      index,
+      isOpenGroupV2,
+      openGroupV2Details,
+    });
+
+    quote.attachments[index] = { ...attachment, thumbnail };
+  }
 
   message.set({ quote });
 

--- a/ts/test/automation/disappearing_messages.spec.ts
+++ b/ts/test/automation/disappearing_messages.spec.ts
@@ -23,10 +23,12 @@ sessionTestTwoWindows('Disappearing messages', async ([windowA, windowB]) => {
   await createContact(windowA, windowB, userA, userB);
   // Click on user's avatar to open conversation options
   await clickOnTestIdWithText(windowA, 'conversation-options-avatar');
+  await waitForMatchingText(windowA, 'Your message request has been accepted');
   // Select disappearing messages drop down
-  await clickOnMatchingText(windowA, 'Disappearing messages');
+  await clickOnTestIdWithText(windowA, 'disappearing-messages-dropdown', 'Disappearing messages');
   // Select 5 seconds
-  await clickOnMatchingText(windowA, '5 seconds');
+  await sleepFor(200);
+  await clickOnTestIdWithText(windowA, 'dropdownitem-5-seconds', '5 seconds');
   // Click chevron to close menu
   await clickOnTestIdWithText(windowA, 'back-button-conversation-options');
   // Check config message

--- a/ts/test/automation/message_requests.spec.ts
+++ b/ts/test/automation/message_requests.spec.ts
@@ -84,6 +84,8 @@ test.describe('Message requests', () => {
     await clickOnTestIdWithText(windowB, 'session-confirm-ok-button', 'OK');
     // Navigate back to message request folder to check
     await clickOnTestIdWithText(windowB, 'settings-section');
+
+    await clickOnTestIdWithText(windowB, 'message-requests-settings-menu-item', 'Message Requests');
     // Check config message of message request acceptance
     await waitForMatchingText(windowB, 'No pending message requests');
   });


### PR DESCRIPTION
- `processQuoteAttachments()` correctly updates attachment thumbnails if they need to be downloaded. Before there was sometimes an issue with updating items in quotes.attachments using `Promise.All` while using an `async` map function.
- Don't show the users pubkey in their own quotes in a community