### PR TITLE
Fix typos

### DIFF
--- a/background.html
+++ b/background.html
@@ -24,7 +24,7 @@
             style-src 'self' 'unsafe-inline';"
     />
     <title>Session</title>
-    <link href="images/sesion/session_icon_128.png" rel="shortcut icon" />
+    <link href="images/session/session_icon_128.png" rel="shortcut icon" />
     <link href="stylesheets/dist/manifest.css" rel="stylesheet" type="text/css" />
   </head>
 

--- a/password.html
+++ b/password.html
@@ -23,7 +23,7 @@
             script-src 'self' 'unsafe-inline';
             style-src 'self' 'unsafe-inline';"
     />
-    <link href="images/sesion/session_icon_128.png" rel="shortcut icon" />
+    <link href="images/session/session_icon_128.png" rel="shortcut icon" />
     <link href="stylesheets/dist/manifest.css" rel="stylesheet" type="text/css" />
   </head>
   <body>

--- a/ts/components/SessionContextMenuContainer.tsx
+++ b/ts/components/SessionContextMenuContainer.tsx
@@ -4,7 +4,7 @@ export const SessionContextMenuContainer = styled.div.attrs({
   // custom props
 })`
   .react-contexify {
-    // be sure it is more than the one set for the More Informations screen of messages
+    // be sure it is more than the one set for the More Information screen of messages
     z-index: 30;
     min-width: 200px;
     box-shadow: 0px 0px 10px var(--context-menu-shadow-color) !important;

--- a/ts/components/button/MenuButton.tsx
+++ b/ts/components/button/MenuButton.tsx
@@ -28,7 +28,7 @@ const StyledMenuButton = styled.button`
 `;
 
 /**
- * This is the Session Menu Botton. i.e. the button on top of the conversation list to start a new conversation.
+ * This is the Session Menu Button. i.e. the button on top of the conversation list to start a new conversation.
  * It has two state: selected or not and so we use an checkbox input to keep the state in sync.
  */
 export const MenuButton = () => {

--- a/ts/models/messageType.ts
+++ b/ts/models/messageType.ts
@@ -223,7 +223,7 @@ export const fillMessageAttributesWithDefaults = (
     id: uuidv4(),
     unread: 0, // if nothing is set, this message is considered read
   });
-  // this is just to cleanup a bit the db. delivered and delivered_to were removed, so everytime we load a message
+  // this is just to cleanup a bit the db. delivered and delivered_to were removed, so every time we load a message
   // we make sure to clean those fields in the json.
   // the next commit() will write that to the disk
   if (defaulted.delivered) {

--- a/ts/session/apis/snode_api/SNodeAPI.ts
+++ b/ts/session/apis/snode_api/SNodeAPI.ts
@@ -150,7 +150,7 @@ async function requestSnodesForPubkeyWithTargetNode(
 async function requestSnodesForPubkeyRetryable(pubKey: string): Promise<Array<Snode>> {
   // don't catch exception in here. we want them to bubble up
 
-  // this is the level where our targetNode is not yet known. We retry a few times with a new one everytime.
+  // this is the level where our targetNode is not yet known. We retry a few times with a new one every time.
   // the idea is that the requestSnodesForPubkeyWithTargetNode will remove a failing targetNode
   return pRetry(
     async () => {

--- a/ts/session/apis/snode_api/swarmPolling.ts
+++ b/ts/session/apis/snode_api/swarmPolling.ts
@@ -68,7 +68,7 @@ export class SwarmPolling {
   }
 
   /**
-   * Used fo testing only
+   * Used for testing only
    */
   public resetSwarmPolling() {
     this.groupPolling = [];

--- a/ts/session/group/closed-group.ts
+++ b/ts/session/group/closed-group.ts
@@ -494,7 +494,7 @@ async function generateAndSendNewEncryptionKeyPair(
 
     await addKeyPairToCacheAndDBIfNeeded(toHex(groupId), newKeyPair.toHexKeyPair());
   };
-  // this is to be sent to the group pubkey adress
+  // this is to be sent to the group pubkey address
   await getMessageQueue().sendToGroup(keypairsMessage, messageSentCallback);
 }
 

--- a/ts/session/messages/outgoing/controlMessage/ExpirationTimerUpdateMessage.ts
+++ b/ts/session/messages/outgoing/controlMessage/ExpirationTimerUpdateMessage.ts
@@ -29,7 +29,7 @@ export class ExpirationTimerUpdateMessage extends DataMessage {
 
     data.flags = SignalService.DataMessage.Flags.EXPIRATION_TIMER_UPDATE;
 
-    // FIXME we shouldn't need this once android recieving refactor is done.
+    // FIXME we shouldn't need this once android receiving refactor is done.
     // the envelope stores the groupId for a closed group already.
     if (this.groupId) {
       const groupMessage = new SignalService.GroupContext();

--- a/ts/session/messages/outgoing/visibleMessage/VisibleMessage.ts
+++ b/ts/session/messages/outgoing/visibleMessage/VisibleMessage.ts
@@ -200,7 +200,7 @@ export function buildProfileForOutgoingMessage(params: { lokiProfile?: LokiProfi
 
   const displayName = params.lokiProfile?.displayName;
 
-  // no need to iclude the avatarPointer if there is no profileKey associated with it.
+  // no need to include the avatarPointer if there is no profileKey associated with it.
   const avatarPointer =
     params.lokiProfile?.avatarPointer &&
     !isEmpty(profileKey) &&

--- a/ts/session/sending/MessageQueue.ts
+++ b/ts/session/sending/MessageQueue.ts
@@ -290,7 +290,7 @@ export class MessageQueue {
     const currentDevice = UserUtils.getOurPubKeyFromCache();
     let isSyncMessage = false;
     if (currentDevice && destinationPk.isEqual(currentDevice)) {
-      // We allow a message for ourselve only if it's a ConfigurationMessage, a ClosedGroupNewMessage,
+      // We allow a message for ourselves only if it's a ConfigurationMessage, a ClosedGroupNewMessage,
       // or a message with a syncTarget set.
 
       if (

--- a/ts/test/session/unit/crypto/OpenGroupAuthentication_test.ts
+++ b/ts/test/session/unit/crypto/OpenGroupAuthentication_test.ts
@@ -397,7 +397,7 @@ describe('OpenGroupAuthentication', () => {
     });
 
     it.skip('Should bencode GET request without body successfully', () => {
-      // TODO: change ot accept request info and expect uint8 array output
+      // TODO: change to accept request info and expect uint8 array output
       // const bencoded = encodeV4Request(getDataToEncode);
       // expect(bencoded).to.be.equal('l45:{"method":"GET","endpoint":"/room/test-room"}e');
     });


### PR DESCRIPTION
`codespell --skip=_locales,*.lock -L keypair,keypairs,ons,usera,readby,falsy -w -i 3`