### PR TITLE
chore: fix typos

### DIFF
--- a/background.html
+++ b/background.html
@@ -24,7 +24,7 @@
             style-src 'self' 'unsafe-inline';"
     />
     <title>Session</title>
-    <link href="images/sesion/session_icon_128.png" rel="shortcut icon" />
+    <link href="images/session/session_icon.png" rel="shortcut icon" />
     <link href="stylesheets/dist/manifest.css" rel="stylesheet" type="text/css" />
   </head>
 

--- a/password.html
+++ b/password.html
@@ -23,7 +23,7 @@
             script-src 'self' 'unsafe-inline';
             style-src 'self' 'unsafe-inline';"
     />
-    <link href="images/sesion/session_icon_128.png" rel="shortcut icon" />
+    <link href="images/session/session_icon.png" rel="shortcut icon" />
     <link href="stylesheets/dist/manifest.css" rel="stylesheet" type="text/css" />
   </head>
   <body>

--- a/ts/components/SessionContextMenuContainer.tsx
+++ b/ts/components/SessionContextMenuContainer.tsx
@@ -4,7 +4,7 @@ export const SessionContextMenuContainer = styled.div.attrs({
   // custom props
 })`
   .react-contexify {
-    // be sure it is more than the one set for the More Informations screen of messages
+    // be sure it is more than the one set for the More Information screen of messages
     z-index: 30;
     min-width: 200px;
     box-shadow: 0px 0px 10px var(--context-menu-shadow-color) !important;

--- a/ts/components/button/MenuButton.tsx
+++ b/ts/components/button/MenuButton.tsx
@@ -27,7 +27,7 @@ const StyledMenuButton = styled.button`
 `;
 
 /**
- * This is the Session Menu Botton. i.e. the button on top of the conversation list to start a new conversation.
+ * This is the Session Menu Button. i.e. the button on top of the conversation list to start a new conversation.
  * It has two state: selected or not and so we use an checkbox input to keep the state in sync.
  */
 export const MenuButton = () => {

--- a/ts/models/messageType.ts
+++ b/ts/models/messageType.ts
@@ -228,7 +228,7 @@ export const fillMessageAttributesWithDefaults = (
     id: uuidv4(),
     unread: READ_MESSAGE_STATE.read, // if nothing is set, this message is considered read
   });
-  // this is just to cleanup a bit the db. delivered and delivered_to were removed, so everytime we load a message
+  // this is just to cleanup a bit the db. delivered and delivered_to were removed, so every time we load a message
   // we make sure to clean those fields in the json.
   // the next commit() will write that to the disk
   if (defaulted.delivered) {

--- a/ts/node/sql.ts
+++ b/ts/node/sql.ts
@@ -409,7 +409,7 @@ function getConversationCount() {
 /**
  * Because the argument list can change when saving a conversation (and actually doing a lot of other stuff),
  * it is not a good idea to try to use it to update a conversation while doing migrations.
- * Because everytime you'll update the saveConversation with a new argument, the migration you wrote a month ago still relies on the old way.
+ * Because every time you'll update the saveConversation with a new argument, the migration you wrote a month ago still relies on the old way.
  * Because of that, there is no `instance` argument here, and you should not add one as this is only needed during migrations (which will break if you do it)
  */
 

--- a/ts/session/apis/open_group_api/sogsv3/sogsApiV3.ts
+++ b/ts/session/apis/open_group_api/sogsv3/sogsApiV3.ts
@@ -560,7 +560,7 @@ export const handleBatchPollResults = async (
         case 'updateRoom':
         case 'deleteReaction':
           // we do nothing for all of those, but let's make sure if we ever add something batch polled for, we include it's handling here.
-          // the assertUnreachable will fail to compile everytime we add a new batch poll endpoint without taking care of it.
+          // the assertUnreachable will fail to compile every time we add a new batch poll endpoint without taking care of it.
           break;
         default:
           assertUnreachable(

--- a/ts/session/apis/snode_api/getSwarmFor.ts
+++ b/ts/session/apis/snode_api/getSwarmFor.ts
@@ -83,7 +83,7 @@ async function requestSnodesForPubkeyWithTargetNode(
 async function requestSnodesForPubkeyRetryable(pubKey: string): Promise<Array<Snode>> {
   // don't catch exception in here. we want them to bubble up
 
-  // this is the level where our targetNode is not yet known. We retry a few times with a new one everytime.
+  // this is the level where our targetNode is not yet known. We retry a few times with a new one every time.
   // the idea is that the requestSnodesForPubkeyWithTargetNode will remove a failing targetNode
   return pRetry(
     async () => {

--- a/ts/session/apis/snode_api/swarmPolling.ts
+++ b/ts/session/apis/snode_api/swarmPolling.ts
@@ -91,7 +91,7 @@ export class SwarmPolling {
   }
 
   /**
-   * Used fo testing only
+   * Used for testing only
    */
   public resetSwarmPolling() {
     this.groupPolling = [];

--- a/ts/session/group/closed-group.ts
+++ b/ts/session/group/closed-group.ts
@@ -427,7 +427,7 @@ async function generateAndSendNewEncryptionKeyPair(
     await groupConvo?.commit(); // this makes sure to include the new encryption keypair in the libsession usergroup wrapper
   };
 
-  // this is to be sent to the group pubkey adress
+  // this is to be sent to the group pubkey address
   await getMessageQueue().sendToGroup({
     message: keypairsMessage,
     namespace: SnodeNamespaces.ClosedGroupMessage,

--- a/ts/session/messages/outgoing/visibleMessage/VisibleMessage.ts
+++ b/ts/session/messages/outgoing/visibleMessage/VisibleMessage.ts
@@ -200,7 +200,7 @@ export function buildProfileForOutgoingMessage(params: { lokiProfile?: LokiProfi
 
   const displayName = params.lokiProfile?.displayName;
 
-  // no need to iclude the avatarPointer if there is no profileKey associated with it.
+  // no need to include the avatarPointer if there is no profileKey associated with it.
   const avatarPointer =
     params.lokiProfile?.avatarPointer &&
     !isEmpty(profileKey) &&

--- a/ts/session/sending/MessageQueue.ts
+++ b/ts/session/sending/MessageQueue.ts
@@ -330,7 +330,7 @@ export class MessageQueue {
     const us = UserUtils.getOurPubKeyFromCache();
     let isSyncMessage = false;
     if (us && destinationPk.isEqual(us)) {
-      // We allow a message for ourselve only if it's a ConfigurationMessage, a ClosedGroupNewMessage,
+      // We allow a message for ourselves only if it's a ConfigurationMessage, a ClosedGroupNewMessage,
       // or a message with a syncTarget set.
 
       if (MessageSender.isSyncMessage(message)) {

--- a/ts/session/utils/libsession/libsession_utils_contacts.ts
+++ b/ts/session/utils/libsession/libsession_utils_contacts.ts
@@ -10,9 +10,9 @@ import { PubKey } from '../../types';
  * It allows to make changes to the wrapper and keeps track of the decoded values of those in the in-memory cache named `mappedContactWrapperValues`.
  *
  * The wrapper content is just a blob which has no structure.
- * Rather than having to fetch the required data from it everytime we need it (during each rerendering), we keep a decoded cache here.
+ * Rather than having to fetch the required data from it every time we need it (during each rerendering), we keep a decoded cache here.
  * Essentially, on app start we load all the content from the wrapper with `SessionUtilContact.refreshMappedValue` during the ConversationController initial load.
- * Then, everytime we do a change to the contacts wrapper, we do it through `insertContactFromDBIntoWrapperAndRefresh`.
+ * Then, every time we do a change to the contacts wrapper, we do it through `insertContactFromDBIntoWrapperAndRefresh`.
  * This applies the change from the in-memory conversationModel to the ContactsWrapper, refetch the data from it and update the decoded cache `mappedContactWrapperValues` with the up to date data.
  * It then triggers a UI refresh of that specific conversation with `triggerUIRefresh` to make sure whatever is displayed on screen is still up to date with the wrapper content.
  *


### PR DESCRIPTION
this comes from mdplusplus https://github.com/mdPlusPlus/session-desktop/tree/codespell

duplicated to fix conflicts

from @mdPlusPlus https://github.com/oxen-io/session-desktop/pull/2816

`codespell --skip=_locales,*.lock -L keypair,keypairs,ons,usera,readby,falsy -w -i 3`
