### PR TITLE
Download attachment zero if no event is available

### DIFF
--- a/ts/components/conversation/message/message-content/MessageContextMenu.tsx
+++ b/ts/components/conversation/message/message-content/MessageContextMenu.tsx
@@ -114,7 +114,13 @@ const SaveAttachment = ({ messageId }: MessageId) => {
     (e: any) => {
       // this is quite dirty but considering that we want the context menu of the message to show on click on the attachment
       // and the context menu save attachment item to save the right attachment I did not find a better way for now.
-      let targetAttachmentIndex = e.triggerEvent.path[1].getAttribute('data-attachmentindex');
+      let triggerEvent = e.triggerEvent;
+      let targetAttachmentIndex;
+      if (typeof triggerEvent === 'undefined') {
+          targetAttachmentIndex = 0;
+      } else {
+      	  targetAttachmentIndex = e.triggerEvent.path[1].getAttribute('data-attachmentindex');
+      }
       e.event.stopPropagation();
       if (!attachments?.length || !convoId || !sender) {
         return;

--- a/ts/components/conversation/message/message-content/MessageContextMenu.tsx
+++ b/ts/components/conversation/message/message-content/MessageContextMenu.tsx
@@ -114,12 +114,12 @@ const SaveAttachment = ({ messageId }: MessageId) => {
     (e: any) => {
       // this is quite dirty but considering that we want the context menu of the message to show on click on the attachment
       // and the context menu save attachment item to save the right attachment I did not find a better way for now.
-      let triggerEvent = e.triggerEvent;
+      const triggerEvent = e.triggerEvent;
       let targetAttachmentIndex;
       if (typeof triggerEvent === 'undefined') {
-          targetAttachmentIndex = 0;
+        targetAttachmentIndex = 0;
       } else {
-      	  targetAttachmentIndex = e.triggerEvent.path[1].getAttribute('data-attachmentindex');
+        targetAttachmentIndex = e.triggerEvent.path[1].getAttribute('data-attachmentindex');
       }
       e.event.stopPropagation();
       if (!attachments?.length || !convoId || !sender) {


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [ X] I have read the [README](https://github.com/oxen-io/session-desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/oxen-io/session-desktop/blob/master/CONTRIBUTING.md)

### Contributor checklist:

- [X ] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X ] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/oxen-io/session-desktop/tree/clearnet) branch
- [ X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/oxen-io/session-desktop/blob/master/CONTRIBUTING.md#tests))
- [X ] My changes are ready to be shipped to users

### Description

https://github.com/oxen-io/session-desktop-temp/issues/154
no longer gives an error with this patch.

This fixes the case of messages with one attachment, but downloading the rest of the attachments in messages with more than one attachment has not been tackled yet.

I tested it by executing yarn start-prod on Ubuntu 20.04.