### PR TITLE
Dx commit experience revert

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx lint-staged
+# Disabling this hook for now because the BuildLintCommand has issues. If you have an error in a file that eslint catches the commit fails silently instead of explaining the error (Will 04/09/2023)
+# npx lint-staged


### PR DESCRIPTION
- The pre-commit hook ignores files based on the  `.eslintignore` instead of a hard-coded list
- disabled the pre-commit hook for now because the `buildLintCommand` is broken. If you have a linting error in a file the commit fails silently through a git error message `husky pre-commit hook exited with code 1 (error)` which is not useful.