### PR TITLE
Fix KeeJef gpg pubkey link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Build instructions can be found in [Contributing.md](CONTRIBUTING.md).
 
 Get Kee's key and import it:
 ```
-wget https://raw.githubusercontent.com/oxen-io/oxen-core/master/utils/gpg_keys/KeeJef.asc
+wget https://raw.githubusercontent.com/oxen-io/oxen-core/dev/utils/gpg_keys/KeeJef.asc
 gpg --import KeeJef.asc
 ```
 


### PR DESCRIPTION
Corrects a stale link in the URL to Kee's key.