### PR TITLE
WIP: prevent installs on old windows versions

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,0 +1,16 @@
+!include LogicLib.nsh
+
+Function .onInit
+
+  ; Check Windows major version
+  ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows NT\CurrentVersion" CurrentVersion
+  StrCpy $R1 $R0 1 -1  ; Extract major version (e.g., "10" from "10.0")
+  IntOp $R1 $R1 - 10   ; Subtract 10
+  
+  ; If major version is less than 10, abort
+  ${If} $R1 < 0
+    MessageBox MB_OK|MB_ICONERROR "This application requires Windows 10 or higher."
+    Abort
+  ${EndIf}
+
+FunctionEnd

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -4,12 +4,15 @@
 
     ; Print to console
     DetailPrint "Running preInit macro..."
-
+    !echo "test output"
+    
     ; Check if the GetWindowsVersion macro from WinVer.nsh is available and working
     ${If} ${AtMostWin10}
         DetailPrint "Windows version is at most Windows 10"
+        !echo "Windows version is at most Windows 10"
     ${Else}
         DetailPrint "Windows version is newer than Windows 10"
+        !echo "Windows version is newer than Windows 10"
     ${EndIf}
 
 !macroend

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,16 +1,18 @@
-!include LogicLib.nsh
-
 Function .onInit
 
   ; Check Windows major version
   ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows NT\CurrentVersion" CurrentVersion
   StrCpy $R1 $R0 1 -1  ; Extract major version (e.g., "10" from "10.0")
   IntOp $R1 $R1 - 10   ; Subtract 10
-  
+
   ; If major version is less than 10, abort
-  ${If} $R1 < 0
-    MessageBox MB_OK|MB_ICONERROR "This application requires Windows 10 or higher."
-    Abort
-  ${EndIf}
+  StrCmp $R1 0 noAbort abortInstall
+  goto noAbort
+
+abortInstall:
+  MessageBox MB_OK|MB_ICONERROR "This application requires Windows 10 or higher."
+  Abort
+
+noAbort:
 
 FunctionEnd

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,15 +1,15 @@
-Function .onInit
+!include "LogicLib.nsh"
+!include "WinVer.nsh"
 
-  ; Check Windows major version
-  ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows NT\CurrentVersion" CurrentVersion
-  StrCpy $R1 $R0 1 -1  ; Extract major version (e.g., "10" from "10.0")
-  IntOp $R1 $R1 - 10   ; Subtract 10
-  
-  ; If major version is less than 10, abort
-  StrCmp $R1 0 noAbort
+!macro preInit
+    ; Check the Windows major and minor version numbers
+    ${GetWindowsVersion} $0 $1 $2 $3
 
-Abort "This application requires Windows 10 or higher."
-
-noAbort:
-
-FunctionEnd
+    ; $0 contains the major version, and $1 contains the minor version.
+    ; Windows 10 corresponds to version 10.0.
+    ; If the system's version is less than 10.0, abort the installation.
+    ${If} $0 < 10
+        MessageBox MB_OK|MB_ICONSTOP "This application requires Windows 10 or newer. Installation will now exit."
+        Abort
+    ${EndIf}
+!macroend

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,11 +1,15 @@
-!macro preInit
-    ; Load the Windows version
-    System::Call 'kernel32::GetVersionExA(i r0) i .r1'
-    Pop $0 ; Major version will be popped into $0
+!include "WinVer.nsh"
 
-    ; Check if the version is less than 10
-    ${If} $0 < 10
-        MessageBox MB_OK|MB_ICONSTOP "This application requires Windows 10 or newer. Installation will now exit."
-        Abort
+!macro preInit
+
+    ; Print to console
+    DetailPrint "Running preInit macro..."
+
+    ; Check if the GetWindowsVersion macro from WinVer.nsh is available and working
+    ${If} ${AtMostWin10}
+        DetailPrint "Windows version is at most Windows 10"
+    ${Else}
+        DetailPrint "Windows version is newer than Windows 10"
     ${EndIf}
+
 !macroend

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,13 +1,9 @@
-!include "LogicLib.nsh"
-!include "WinVer.nsh"
-
 !macro preInit
-    ; Check the Windows major and minor version numbers
-    ${GetWindowsVersion} $0 $1 $2 $3
+    ; Load the Windows version
+    System::Call 'kernel32::GetVersionExA(i r0) i .r1'
+    Pop $0 ; Major version will be popped into $0
 
-    ; $0 contains the major version, and $1 contains the minor version.
-    ; Windows 10 corresponds to version 10.0.
-    ; If the system's version is less than 10.0, abort the installation.
+    ; Check if the version is less than 10
     ${If} $0 < 10
         MessageBox MB_OK|MB_ICONSTOP "This application requires Windows 10 or newer. Installation will now exit."
         Abort

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -4,14 +4,11 @@ Function .onInit
   ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows NT\CurrentVersion" CurrentVersion
   StrCpy $R1 $R0 1 -1  ; Extract major version (e.g., "10" from "10.0")
   IntOp $R1 $R1 - 10   ; Subtract 10
-
+  
   ; If major version is less than 10, abort
-  StrCmp $R1 0 noAbort abortInstall
-  goto noAbort
+  StrCmp $R1 0 noAbort
 
-abortInstall:
-  MessageBox MB_ICONERROR|MB_OK "This application requires Windows 10 or higher."
-  Abort
+Abort "This application requires Windows 10 or higher."
 
 noAbort:
 

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -10,7 +10,7 @@ Function .onInit
   goto noAbort
 
 abortInstall:
-  MessageBox MB_OK|MB_ICONERROR "This application requires Windows 10 or higher."
+  MessageBox MB_ICONERROR|MB_OK "This application requires Windows 10 or higher."
   Abort
 
 noAbort:

--- a/package.json
+++ b/package.json
@@ -250,7 +250,8 @@
     "nsis": {
       "deleteAppDataOnUninstall": true,
       "oneClick": false,
-      "allowToChangeInstallationDirectory": true
+      "allowToChangeInstallationDirectory": true,
+      "script": "build/installer.nsh"
     },
     "linux": {
       "category": "Network",

--- a/package.json
+++ b/package.json
@@ -250,8 +250,7 @@
     "nsis": {
       "deleteAppDataOnUninstall": true,
       "oneClick": false,
-      "allowToChangeInstallationDirectory": true,
-      "script": "build/installer.nsh"
+      "allowToChangeInstallationDirectory": true
     },
     "linux": {
       "category": "Network",

--- a/package.json
+++ b/package.json
@@ -250,7 +250,8 @@
     "nsis": {
       "deleteAppDataOnUninstall": true,
       "oneClick": false,
-      "allowToChangeInstallationDirectory": true
+      "allowToChangeInstallationDirectory": true,
+      "include": "build/installer.nsh"
     },
     "linux": {
       "category": "Network",


### PR DESCRIPTION
Session isnt working on Windows versions 7 and 8.1 since Electron no longer supports those Windows versions, however the installer will still run to install Session, this PR is a WIP to prevent the Windows installer running on older versions of Windows. 