### PR TITLE
chore: updated electron to v25.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "cross-env": "^6.0.3",
     "css-loader": "^6.7.2",
     "dmg-builder": "23.6.0",
-    "electron": "^25.8.1",
+    "electron": "^25.8.4",
     "electron-builder": "23.0.8",
     "eslint": "^8.45.0",
     "eslint-config-airbnb-base": "^15.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2990,10 +2990,10 @@ electron@*:
     "@types/node" "^18.11.18"
     extract-zip "^2.0.1"
 
-electron@^25.8.1:
-  version "25.8.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-25.8.1.tgz#092fab5a833db4d9240d4d6f36218cf7ca954f86"
-  integrity sha512-GtcP1nMrROZfFg0+mhyj1hamrHvukfF6of2B/pcWxmWkd5FVY1NJib0tlhiorFZRzQN5Z+APLPr7aMolt7i2AQ==
+electron@^25.8.4:
+  version "25.8.4"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-25.8.4.tgz#b50877aac7d96323920437baf309ad86382cb455"
+  integrity sha512-hUYS3RGdaa6E1UWnzeGnsdsBYOggwMMg4WGxNGvAoWtmRrr6J1BsjFW/yRq4WsJHJce2HdzQXtz4OGXV6yUCLg==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"


### PR DESCRIPTION
Relates [CVE-2023-5217](https://github.com/advisories/GHSA-qqvq-6xgj-jw8g)

electron backported the fix to 25.8.4: https://releases.electronjs.org/release/v25.8.4