### PR TITLE
fix: allow user to delete unsent messages

### DIFF
--- a/ts/components/conversation/message/message-content/MessageContextMenu.tsx
+++ b/ts/components/conversation/message/message-content/MessageContextMenu.tsx
@@ -89,12 +89,19 @@ const StyledEmojiPanelContainer = styled.div<{ x: number; y: number }>`
 const DeleteForEveryone = ({ messageId }: { messageId: string }) => {
   const convoId = useSelectedConversationKey();
   const isDeletableForEveryone = useMessageIsDeletableForEveryone(messageId);
+  const status = useMessageStatus(messageId);
+  const direction = useMessageDirection(messageId);
+
   if (!convoId || !isDeletableForEveryone) {
     return null;
   }
   const onDeleteForEveryone = () => {
     void deleteMessagesByIdForEveryone([messageId], convoId);
   };
+
+  if (status === 'error' && direction === 'outgoing') {
+    return null;
+  }
 
   const unsendMessageText = window.i18n('deleteForEveryone');
 
@@ -183,6 +190,8 @@ export const MessageContextMenu = (props: Props) => {
 
   const isOutgoing = direction === 'outgoing';
   const isSent = status === 'sent' || status === 'read'; // a read message should be replyable
+  const isError = status === 'error';
+  const isDeletableForMe = (isDeletable && !isPublic) || (isOutgoing && isError);
 
   const emojiPanelRef = useRef<HTMLDivElement>(null);
   const [showEmojiPanel, setShowEmojiPanel] = useState(false);
@@ -366,9 +375,7 @@ export const MessageContextMenu = (props: Props) => {
           )}
           <RetryItem messageId={messageId} />
           {isDeletable ? <Item onClick={onSelect}>{selectMessageText}</Item> : null}
-          {isDeletable && !isPublic ? (
-            <Item onClick={onDelete}>{deleteMessageJustForMeText}</Item>
-          ) : null}
+          {isDeletableForMe ? <Item onClick={onDelete}>{deleteMessageJustForMeText}</Item> : null}
           <DeleteForEveryone messageId={messageId} />
           <AdminActionItems messageId={messageId} />
         </Menu>


### PR DESCRIPTION
This is a proxy pull request from the following codeberg branch, https://codeberg.org/gravel/session-desktop/commits/branch/delete-unsent-messages

```
Messages sent to open groups can fail to send.

However, users are unable to delete unsent open group messages,
as the 'Delete for everyone' option mandates that
open group messages must be deleted from the server
before being deleted locally, and no other delete option is shown.
Furthermore, in open groups, the 'Delete just for me' option
fails to trigger a distinct code path from 'Delete for everyone'.

This commit enables the 'Delete just for me' context menu option
for all outgoing messages with status 'error'.
To direct the user to the appropriate action,
this commit also hides the 'Delete for everyone' option
for the same messages. Lastly, it also implements the missing
'Delete for me' functionality for open group messages.
```

Relates: oxen-io/session-desktop-temp#226