### PR TITLE
Update unread message theming and alignment 

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -255,8 +255,6 @@
 
 .module-conversation__user,
 .module-message__author {
-  margin-top: var(--margins-sm);
-  margin-bottom: var(--margins-xs);
   font-size: var(--font-size-sm);
   font-weight: 300;
   line-height: 18px;
@@ -621,6 +619,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
+  margin-bottom: var(--margins-xs);
 }
 
 .module-conversation-list-item__header__name {

--- a/ts/components/leftpane/MessageRequestsBanner.tsx
+++ b/ts/components/leftpane/MessageRequestsBanner.tsx
@@ -45,7 +45,8 @@ const StyledCircleIcon = styled.div`
 const StyledUnreadCounter = styled.div`
   font-weight: bold;
   border-radius: var(--margins-sm);
-  background-color: var(--conversation-tab-bubble-background-color);
+  color: var(--unread-messages-alert-text-color);
+  background-color: var(--unread-messages-alert-background-color);
   margin-left: var(--margins-sm);
   min-width: 20px;
   height: 20px;


### PR DESCRIPTION
This PR fixes unread message bubbles in message requests, so that they use the same colors as unread message bubbles for conversation items, previously they were deviating. See below

![image](https://github.com/oxen-io/session-desktop/assets/27277414/b3802a5d-1249-48c5-9a5d-093aa21cd49f)

This is now fixed as such 

![image](https://github.com/oxen-io/session-desktop/assets/27277414/7fb14a3c-3ced-4ae3-9826-a7d1484f6228)

it also vertically aligns all conversation header items, so that author name, unread count and date are inline 