### PR TITLE
Fix: change reaction container to use group avatar list margin width

### DIFF
--- a/ts/components/conversation/message/message-content/MessageReactions.tsx
+++ b/ts/components/conversation/message/message-content/MessageReactions.tsx
@@ -27,7 +27,7 @@ export const StyledMessageReactionsContainer = styled(Flex)<{
   }
 
   // MessageAvatar width + margin-inline-end
-  ${props => !props.noAvatar && 'margin-inline-start: calc(36px + 20px);'}
+  ${props => !props.noAvatar && 'margin-inline-start: var(--width-avatar-group-msg-list);'}
 `;
 
 export const StyledMessageReactions = styled(Flex)<{ fullWidth: boolean }>`


### PR DESCRIPTION
Changed the message reaction container margin to use the avatar list width

![image](https://github.com/oxen-io/session-desktop/assets/5667907/44d6d044-b6f6-47e4-b1b1-03a1805582e9)
