### PR TITLE
Fix: render mentions in private chat message body

### DIFF
--- a/ts/components/conversation/message/message-content/MessageBody.tsx
+++ b/ts/components/conversation/message/message-content/MessageBody.tsx
@@ -33,7 +33,7 @@ const renderNewLines: RenderTextCallbackType = ({ text: textWithNewLines, key, i
     <AddNewLines
       key={key}
       text={textWithNewLines}
-      renderNonNewLine={isGroup ? renderMentions : renderTextDefault}
+      renderNonNewLine={renderMentions}
       isGroup={isGroup}
     />
   );


### PR DESCRIPTION
Made it so mentions are rendered in private chats. While they are disabled on private chats, if you send manually @<the full pk> it now replaces the full pk with the nickname/name/You of the mentioned user.