### PR TITLE
feat: option to change UI language

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -579,5 +579,7 @@
   "duration": "Duration",
   "notApplicable": "N/A",
   "unknownError": "Unknown Error",
-  "displayNameErrorNew": "We were unable to load your display name. Please enter a new display name to continue."
+  "displayNameErrorNew": "We were unable to load your display name. Please enter a new display name to continue.",
+  "uiLanguage": "Interface language",
+  "uiLanguageDescription": "Changing language will restart the app"
 }

--- a/preload.js
+++ b/preload.js
@@ -207,6 +207,11 @@ window.setAutoUpdateEnabled = value => {
   ipc.send('set-auto-update-setting', !!value);
 };
 
+window.getUiLanguage = () => ipc.sendSync('get-ui-language');
+window.setUiLanguage = value => {
+  ipc.send('set-ui-language', String(value));
+};
+
 ipc.on('get-ready-for-shutdown', async () => {
   const { shutdown } = window.Events || {};
   if (!shutdown) {

--- a/ts/components/settings/SettingsSessionUiLanguage.tsx
+++ b/ts/components/settings/SettingsSessionUiLanguage.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import styled from 'styled-components';
+import { SessionSettingsItemWrapper } from './SessionSettingListItem';
+
+const StyledSessionSelectContainer = styled.div`
+  position: relative;
+`;
+
+const StyledSessionSelect = styled.select`
+  padding: 0.5em;
+  margin: 0.5em 0;
+  font-size: 1em;
+  border: 1px solid var(--input-border-color);
+  border-radius: 5px;
+  padding: 8px 16px;
+  transition: var(--default-duration);
+  color: var(--settings-tab-text-color);
+  background-image: none !important;
+`;
+
+const StyledSelectArrow = styled.span`
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid var(--input-border-color);
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  right: 16px;
+  z-index: 10;
+  pointer-events: none;
+`;
+
+export const SettingsSessionUiLanguage = () => {
+  const [uiLanguage, setUiLanguage] = React.useState(window.getUiLanguage());
+
+  return (
+    <SessionSettingsItemWrapper
+      inline
+      title={window.i18n('uiLanguage')}
+      description={window.i18n('uiLanguageDescription')}
+    >
+      <StyledSessionSelectContainer>
+        <StyledSessionSelect
+          value={uiLanguage}
+          onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+            setUiLanguage(e.target.value);
+            window.setUiLanguage(e.target.value);
+          }}
+        >
+          <option value="ar">العربية</option>
+          <option value="be">Беларуская</option>
+          <option value="bg">Български</option>
+          <option value="ca">Català</option>
+          <option value="cs">Čeština</option>
+          <option value="da">Dansk</option>
+          <option value="de">Deutsch</option>
+          <option value="el">Ελληνικά</option>
+          <option value="en">English</option>
+          <option value="eo">Esperanto</option>
+          <option value="es">Español</option>
+          <option value="es_419">Español (Latinoamérica)</option>
+          <option value="et">Eesti</option>
+          <option value="fa">فارسی</option>
+          <option value="fi">Suomi</option>
+          <option value="fil">Filipino</option>
+          <option value="fr">Français</option>
+          <option value="he">עברית</option>
+          <option value="hi">हिन्दी</option>
+          <option value="hr">Hrvatski</option>
+          <option value="hu">Magyar</option>
+          <option value="hy-AM">Հայերեն</option>
+          <option value="id">Bahasa Indonesia</option>
+          <option value="it">Italiano</option>
+          <option value="ja">日本語</option>
+          <option value="ka">ქართული</option>
+          <option value="km">ភាសាខ្មែរ</option>
+          <option value="kmr">Kurmancî</option>
+          <option value="kn">ಕನ್ನಡ</option>
+          <option value="ko">한국어</option>
+          <option value="lt">Lietuvių</option>
+          <option value="lv">Latviešu</option>
+          <option value="mk">Македонски</option>
+          <option value="nb">Norsk Bokmål</option>
+          <option value="nl">Nederlands</option>
+          <option value="no">Norsk</option>
+          <option value="pa">ਪੰਜਾਬੀ</option>
+          <option value="pl">Polski</option>
+          <option value="pt_BR">Português (Brasil)</option>
+          <option value="pt_PT">Português (Portugal)</option>
+          <option value="ro">Română</option>
+          <option value="ru">Русский</option>
+          <option value="si">සිංහල</option>
+          <option value="sk">Slovenčina</option>
+          <option value="sl">Slovenščina</option>
+          <option value="sq">Shqip</option>
+          <option value="sr">Српски</option>
+          <option value="sv">Svenska</option>
+          <option value="ta">தமிழ்</option>
+          <option value="th">ไทย</option>
+          <option value="tl">Tagalog</option>
+          <option value="tr">Türkçe</option>
+          <option value="uk">Українська</option>
+          <option value="uz">O‘zbek</option>
+          <option value="vi">Tiếng Việt</option>
+          <option value="zh_CN">中文 (简体)</option>
+          <option value="zh_TW">中文 (繁體)</option>
+        </StyledSessionSelect>
+        <StyledSelectArrow />
+      </StyledSessionSelectContainer>
+    </SessionSettingsItemWrapper>
+  );
+};

--- a/ts/components/settings/section/CategoryAppearance.tsx
+++ b/ts/components/settings/section/CategoryAppearance.tsx
@@ -8,6 +8,7 @@ import { isHideMenuBarSupported } from '../../../types/Settings';
 import { SessionToggleWithDescription } from '../SessionSettingListItem';
 import { SettingsThemeSwitcher } from '../SettingsThemeSwitcher';
 import { ZoomingSessionSlider } from '../ZoomingSessionSlider';
+import { SettingsSessionUiLanguage } from '../SettingsSessionUiLanguage';
 
 export const SettingsCategoryAppearance = () => {
   const forceUpdate = useUpdate();
@@ -20,6 +21,7 @@ export const SettingsCategoryAppearance = () => {
 
   return (
     <>
+      <SettingsSessionUiLanguage />
       <SettingsThemeSwitcher />
       <ZoomingSessionSlider />
       {isHideMenuBarSupported() && (

--- a/ts/mains/main_node.ts
+++ b/ts/mains/main_node.ts
@@ -752,7 +752,8 @@ app.on('ready', async () => {
   assertLogger().info('app ready');
   assertLogger().info(`starting version ${packageJson.version}`);
   if (!locale) {
-    const appLocale = process.env.LANGUAGE || app.getLocale() || 'en';
+    const appLocale =
+      (userConfig.get('uiLanguage') as string) || process.env.LANGUAGE || app.getLocale() || 'en';
     locale = loadLocale({ appLocale, logger });
     assertLogger().info(`locale is ${appLocale}`);
   }
@@ -1148,6 +1149,23 @@ ipc.on('set-auto-update-setting', async (_event, enabled) => {
 
 ipc.on('get-native-theme', event => {
   event.sender.send('send-native-theme', nativeTheme.shouldUseDarkColors);
+});
+
+ipc.on('get-ui-language', async event => {
+  const uiLocaleName = String(
+    userConfig.get('uiLanguage') || process.env.LANGUAGE || app.getLocale() || 'en'
+  );
+
+  const normalizedLocale = uiLocaleName.split('_')[0].toLowerCase();
+
+  // eslint-disable-next-line no-param-reassign
+  event.returnValue = normalizedLocale;
+});
+
+ipc.on('set-ui-language', async (_event, uiLanguage) => {
+  userConfig.set('uiLanguage', uiLanguage);
+  app.relaunch();
+  app.exit();
 });
 
 nativeTheme.on('updated', () => {

--- a/ts/types/LocalizerKeys.ts
+++ b/ts/types/LocalizerKeys.ts
@@ -534,6 +534,8 @@ export type LocalizerKeys =
   | 'typingAlt'
   | 'typingIndicatorsSettingDescription'
   | 'typingIndicatorsSettingTitle'
+  | 'uiLanguage'
+  | 'uiLanguageDescription'
   | 'unableToCall'
   | 'unableToCallTitle'
   | 'unableToLoadAttachment'

--- a/ts/window.d.ts
+++ b/ts/window.d.ts
@@ -97,6 +97,8 @@ declare global {
     closeDebugLog: () => void;
     getAutoUpdateEnabled: () => boolean;
     setAutoUpdateEnabled: (enabled: boolean) => void;
+    getUiLanguage: () => string;
+    setUiLanguage: (language: string) => void;
     setZoomFactor: (newZoom: number) => void;
     updateZoomFactor: () => void;
 


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/oxen-io/session-desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/oxen-io/session-desktop/blob/master/CONTRIBUTING.md)

### Contributor checklist:

- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/oxen-io/session-desktop/tree/clearnet) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/oxen-io/session-desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/loki-project/loki-messenger/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes oxen-io/session-desktop#222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
Feature request: oxen-io/session-desktop-temp#590 

This PR adds option to change app's UI language in settings under Appearance tab. 
I've used native `<select>` tag and hardcoded all languages as `<option>` tags.
I've used dynamic CSS variables for theming and `transition: var(--default-duration)` for theme animation.

<img src="https://github.com/oxen-io/session-desktop/assets/59040542/59475998-b5bd-4a50-ab56-e2febdc6deae" width="600" />
<img src="https://github.com/oxen-io/session-desktop/assets/59040542/d01c4628-aeac-49e6-9320-cfd079b1bad2" width="300" />
<img src="https://github.com/oxen-io/session-desktop/assets/59040542/b53b9afc-8894-4003-8a0c-3af7d5fa5755" width="300" />
<img src="https://github.com/oxen-io/session-desktop/assets/59040542/57f1f0bc-98e4-48c1-b24e-4e58ce0f4c79" width="300" />
<img src="https://github.com/oxen-io/session-desktop/assets/59040542/cdf5beb3-b0a4-456a-9661-6963991dca10" width="300" />

I've used userConfig which stores data to config.json (`uiLanguage` property) to save and load language set by user. If language isn't set yet, it falls back to default language, evaluating this: `process.env.LANGUAGE || app.getLocale() || 'en'`. After choosing language, app is restarted using `app.relaunch(); app.exit();`

I've added two events to ipc: `get-ui-language`, `set-ui-language `.

I've added two translation keys: `uiLanguage`, `uiLanguageDescription`.