### PR TITLE
Change max avatar size to match other platforms

### DIFF
--- a/ts/session/constants.ts
+++ b/ts/session/constants.ts
@@ -17,6 +17,15 @@ export const DURATION = {
   WEEKS: days * 7,
 };
 
+export const FILESIZE = {
+  /** 1KB */
+  KB: 1024,
+  /** 1MB */
+  MB: 1024 * 1024,
+  /** 1GB */
+  GB: 1024 * 1024 * 1024,
+};
+
 export const TTL_DEFAULT = {
   /** 20 seconds */
   TYPING_MESSAGE: 20 * DURATION.SECONDS,

--- a/ts/util/attachmentsUtil.ts
+++ b/ts/util/attachmentsUtil.ts
@@ -3,6 +3,7 @@ import imageType from 'image-type';
 
 import { arrayBufferToBlob } from 'blob-util';
 import loadImage from 'blueimp-load-image';
+import fileSize from 'filesize';
 import { StagedAttachmentType } from '../components/conversation/composition/CompositionBox';
 import { SignalService } from '../protobuf';
 import { getDecryptedMediaUrl } from '../session/crypto/DecryptedAttachmentsManager';
@@ -53,7 +54,7 @@ export async function autoScaleForAvatar<T extends { contentType: string; blob: 
 ) {
   const maxMeasurements = {
     maxSide: AVATAR_MAX_SIDE,
-    maxSize: 1000 * 1024,
+    maxSize: 5 * 1024 * 1024,
   };
 
   // we can only upload jpeg, gif, or png as avatar/opengroup
@@ -79,7 +80,7 @@ export async function autoScaleForAvatar<T extends { contentType: string; blob: 
 export async function autoScaleForIncomingAvatar(incomingAvatar: ArrayBuffer) {
   const maxMeasurements = {
     maxSide: AVATAR_MAX_SIDE,
-    maxSize: 1000 * 1024,
+    maxSize: 5 * 1024 * 1024,
   };
 
   // the avatar url send in a message does not contain anything related to the avatar MIME type, so
@@ -186,7 +187,7 @@ export async function autoScale<T extends { contentType: string; blob: Blob }>(
   }
 
   if (blob.type === IMAGE_GIF && blob.size > maxSize) {
-    throw new Error(`GIF is too large, required size is ${maxSize}`);
+    throw new Error(`GIF is too large. Max size: ${fileSize(maxSize, { base: 10, round: 0 })}`);
   }
 
   perfStart(`loadimage-*${blob.size}`);

--- a/ts/util/attachmentsUtil.ts
+++ b/ts/util/attachmentsUtil.ts
@@ -13,7 +13,7 @@ import { IMAGE_GIF, IMAGE_JPEG, IMAGE_PNG, IMAGE_TIFF, IMAGE_UNKNOWN } from '../
 import { getAbsoluteAttachmentPath, processNewAttachment } from '../types/MessageAttachment';
 import { THUMBNAIL_SIDE } from '../types/attachments/VisualAttachment';
 
-import { MAX_ATTACHMENT_FILESIZE_BYTES } from '../session/constants';
+import { FILESIZE, MAX_ATTACHMENT_FILESIZE_BYTES } from '../session/constants';
 import { perfEnd, perfStart } from '../session/utils/Performance';
 
 /**
@@ -54,7 +54,7 @@ export async function autoScaleForAvatar<T extends { contentType: string; blob: 
 ) {
   const maxMeasurements = {
     maxSide: AVATAR_MAX_SIDE,
-    maxSize: 5 * 1024 * 1024,
+    maxSize: 5 * FILESIZE.MB,
   };
 
   // we can only upload jpeg, gif, or png as avatar/opengroup
@@ -80,7 +80,7 @@ export async function autoScaleForAvatar<T extends { contentType: string; blob: 
 export async function autoScaleForIncomingAvatar(incomingAvatar: ArrayBuffer) {
   const maxMeasurements = {
     maxSide: AVATAR_MAX_SIDE,
-    maxSize: 5 * 1024 * 1024,
+    maxSize: 5 * FILESIZE.MB,
   };
 
   // the avatar url send in a message does not contain anything related to the avatar MIME type, so


### PR DESCRIPTION
Before:
[Screencast from 2024-05-02 11-21-59.webm](https://github.com/oxen-io/session-desktop/assets/5667907/d4d0d333-3d20-44a0-ad4b-7512096da13d)

After:

![Screenshot from 2024-05-02 14-11-55](https://github.com/oxen-io/session-desktop/assets/5667907/d1067525-76a1-481e-9086-81fd47965afb)
Also change the max avatar file size to 5MB to be in line with IOS and Android.