### PR TITLE
feat: add back button in navigation bar when navigating from communities to message author's DM

### DIFF
--- a/ts/components/conversation/header/ConversationHeader.tsx
+++ b/ts/components/conversation/header/ConversationHeader.tsx
@@ -1,24 +1,44 @@
 import React from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
-import { isMessageSelectionMode } from '../../../state/selectors/conversations';
+import {
+  getReturnToConversation,
+  isMessageSelectionMode,
+} from '../../../state/selectors/conversations';
 
-import { openRightPanel } from '../../../state/ducks/conversations';
+import {
+  openConversationToSpecificMessage,
+  openRightPanel,
+  resetReturnConversation,
+} from '../../../state/ducks/conversations';
 
 import { useSelectedConversationKey } from '../../../state/selectors/selectedConversation';
 import { Flex } from '../../basic/Flex';
-import { AvatarHeader, CallButton } from './ConversationHeaderItems';
+import { AvatarHeader, BackButton, CallButton } from './ConversationHeaderItems';
 import { SelectionOverlay } from './ConversationHeaderSelectionOverlay';
 import { ConversationHeaderTitle } from './ConversationHeaderTitle';
 
 export const ConversationHeaderWithDetails = () => {
   const isSelectionMode = useSelector(isMessageSelectionMode);
+  const returnToConversation = useSelector(getReturnToConversation);
   const selectedConvoKey = useSelectedConversationKey();
   const dispatch = useDispatch();
 
   if (!selectedConvoKey) {
     return null;
   }
+
+  const handleGoBack = async () => {
+    if (!returnToConversation) {
+      return;
+    }
+    await openConversationToSpecificMessage({
+      conversationKey: returnToConversation.key,
+      messageIdToNavigateTo: returnToConversation.messageId,
+      shouldHighlightMessage: false,
+    });
+    void dispatch(resetReturnConversation());
+  };
 
   return (
     <div className="module-conversation-header">
@@ -29,6 +49,11 @@ export const ConversationHeaderWithDetails = () => {
         width="100%"
         flexGrow={1}
       >
+        <BackButton
+          onGoBack={() => void handleGoBack()}
+          showBackButton={returnToConversation !== undefined}
+        />
+
         <ConversationHeaderTitle />
 
         {!isSelectionMode && (

--- a/ts/components/conversation/message/message-content/MessageAvatar.tsx
+++ b/ts/components/conversation/message/message-content/MessageAvatar.tsx
@@ -108,7 +108,14 @@ export const MessageAvatar = (props: Props) => {
 
       // public and blinded key for that message, we should open the convo as is and see if the user wants
       // to send a sogs blinded message request.
-      await openConversationWithMessages({ conversationKey: privateConvoToOpen, messageId: null });
+      await openConversationWithMessages({
+        conversationKey: privateConvoToOpen,
+        returnToConversation: {
+          key: selectedConvoKey,
+          messageId,
+        },
+        messageId: null,
+      });
 
       return;
     }

--- a/ts/state/selectors/conversations.ts
+++ b/ts/state/selectors/conversations.ts
@@ -12,6 +12,7 @@ import {
   PropsForQuote,
   QuoteLookupType,
   ReduxConversationType,
+  ReturnToConversationProps,
   SortedMessageModelProps,
 } from '../ducks/conversations';
 import { StateType } from '../reducer';
@@ -497,6 +498,9 @@ export const isRightPanelShowing = (state: StateType): boolean =>
 
 export const isMessageSelectionMode = (state: StateType): boolean =>
   state.conversations.selectedMessageIds.length > 0;
+
+export const getReturnToConversation = (state: StateType): ReturnToConversationProps | undefined =>
+  state.conversations.returnToConversation;
 
 export const getSelectedMessageIds = (state: StateType): Array<string> =>
   state.conversations.selectedMessageIds;


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/oxen-io/session-desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/oxen-io/session-desktop/blob/master/CONTRIBUTING.md)

### Contributor checklist:

- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/oxen-io/session-desktop/tree/clearnet) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/oxen-io/session-desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/loki-project/loki-messenger/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes oxen-io/session-desktop#222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

I have added `returnToConversation` state property that has ReturnToConversationProps type. It is where information stored about where to navigate when user presses back button in navigation bar when returning from direct messages conversation with Community participant. 

![telegram-cloud-photo-size-2-5325704201331927275-y](https://github.com/oxen-io/session-desktop/assets/59040542/98381b66-a491-4018-a9b1-d1bf8774ecfb)

I have used existing BackButton component and openConversationToSpecificMessage function to navigate user exactly where they were before pressing avatar of some other user. 

Also I handled cases like deleting returning conversation while in DMs (user navigates to someone's DM -> deletes community) and deleting current selected conversation while having return state (user navigated to someone's DM conversation -> deletes it) — in both cases returnToConversation is reset, hiding back button.

See oxen-io/session-desktop-temp#314