### PR TITLE
Restoring an account should restore all groups

### DIFF
--- a/ts/components/conversation/Timestamp.tsx
+++ b/ts/components/conversation/Timestamp.tsx
@@ -39,14 +39,21 @@ export const Timestamp = (props: Props) => {
     return null;
   }
 
-  const momentValue = moment(timestamp);
-  // this is a hack to make the date string shorter, looks like moment does not have a localized way of doing this for now.
+  let title = '';
+  let dateString = '';
 
-  const dateString = momentFromNow
-    ? momentValue.fromNow().replace('minutes', 'mins').replace('minute', 'min')
-    : momentValue.format('lll');
+  // NOTE some existing groups might not have a joinedAtSeconds and we use a fallback value of 1 in order to poll and show up in the conversations list
+  if (timestamp !== 1) {
+    const momentValue = moment(timestamp);
+    // this is a hack to make the date string shorter, looks like moment does not have a localized way of doing this for now.
 
-  const title = moment(timestamp).format('llll');
+    dateString = momentFromNow
+      ? momentValue.fromNow().replace('minutes', 'mins').replace('minute', 'min')
+      : momentValue.format('lll');
+
+    title = moment(timestamp).format('llll');
+  }
+
   if (props.isConversationListItem) {
     return <TimestampContainerListItem title={title}>{dateString}</TimestampContainerListItem>;
   }

--- a/ts/components/conversation/Timestamp.tsx
+++ b/ts/components/conversation/Timestamp.tsx
@@ -3,6 +3,7 @@ import moment from 'moment';
 import useInterval from 'react-use/lib/useInterval';
 import useUpdate from 'react-use/lib/useUpdate';
 import styled from 'styled-components';
+import { CONVERSATION } from '../../session/constants';
 
 type Props = {
   timestamp?: number;
@@ -42,8 +43,7 @@ export const Timestamp = (props: Props) => {
   let title = '';
   let dateString = '';
 
-  // NOTE some existing groups might not have a joinedAtSeconds and we use a fallback value of 1 in order to poll and show up in the conversations list
-  if (timestamp !== 1) {
+  if (timestamp !== CONVERSATION.LAST_JOINED_FALLBACK_TIMESTAMP) {
     const momentValue = moment(timestamp);
     // this is a hack to make the date string shorter, looks like moment does not have a localized way of doing this for now.
 

--- a/ts/components/leftpane/overlay/OverlayClosedGroup.tsx
+++ b/ts/components/leftpane/overlay/OverlayClosedGroup.tsx
@@ -58,7 +58,7 @@ const NoContacts = () => {
 };
 
 /**
- * Makes some validity check and return true if the group was indead created
+ * Makes some validity check and return true if the group was indeed created
  */
 async function createClosedGroupWithErrorHandling(
   groupName: string,
@@ -75,13 +75,14 @@ async function createClosedGroupWithErrorHandling(
     return false;
   }
 
-  // >= because we add ourself as a member AFTER this. so a 10 group is already invalid as it will be 11 with ourself
+  // >= because we add ourself as a member AFTER this. so a 10 group is already invalid as it will be 11 when we are included
   // the same is valid with groups count < 1
 
   if (groupMemberIds.length < 1) {
     onError(window.i18n('pickClosedGroupMember'));
     return false;
   }
+
   if (groupMemberIds.length >= VALIDATION.CLOSED_GROUP_SIZE_LIMIT) {
     onError(window.i18n('closedGroupMaxSize'));
     return false;

--- a/ts/receiver/configMessage.ts
+++ b/ts/receiver/configMessage.ts
@@ -603,7 +603,9 @@ async function handleLegacyGroupUpdate(latestEnvelopeTimestamp: number) {
     const members = fromWrapper.members.map(m => m.pubkeyHex);
     const admins = fromWrapper.members.filter(m => m.isAdmin).map(m => m.pubkeyHex);
 
-    const creationTimestamp = fromWrapper.joinedAtSeconds ? fromWrapper.joinedAtSeconds * 1000 : 0;
+    // NOTE some existing groups might not have a joinedAtSeconds and we need a truthy fallback value in order to poll and show up in the conversations list
+    const creationTimestamp = fromWrapper.joinedAtSeconds ? fromWrapper.joinedAtSeconds * 1000 : 1;
+
     // then for all the existing legacy group in the wrapper, we need to override the field of what we have in the DB with what is in the wrapper
     // We only set group admins on group creation
     const groupDetails: ClosedGroup.GroupInfo = {
@@ -643,13 +645,12 @@ async function handleLegacyGroupUpdate(latestEnvelopeTimestamp: number) {
 
     const existingTimestampMs = legacyGroupConvo.get('lastJoinedTimestamp');
     const existingJoinedAtSeconds = Math.floor(existingTimestampMs / 1000);
-    if (existingJoinedAtSeconds !== fromWrapper.joinedAtSeconds) {
+    if (existingJoinedAtSeconds !== creationTimestamp) {
       legacyGroupConvo.set({
-        lastJoinedTimestamp: fromWrapper.joinedAtSeconds * 1000,
+        lastJoinedTimestamp: creationTimestamp,
       });
       changes = true;
     }
-
     // start polling for this group if we haven't left it yet. The wrapper does not store this info for legacy group so we check from the DB entry instead
     if (!legacyGroupConvo.get('isKickedFromGroup') && !legacyGroupConvo.get('left')) {
       getSwarmPollingInstance().addGroupId(PubKey.cast(fromWrapper.pubkeyHex));

--- a/ts/receiver/configMessage.ts
+++ b/ts/receiver/configMessage.ts
@@ -52,6 +52,7 @@ import { HexKeyPair } from './keypairs';
 import { queueAllCachedFromSource } from './receiver';
 import { EnvelopePlus } from './types';
 import { ConversationTypeEnum, CONVERSATION_PRIORITIES } from '../models/types';
+import { CONVERSATION } from '../session/constants';
 
 function groupByNamespace(incomingConfigs: Array<RetrieveMessageItemWithNamespace>) {
   const groupedByVariant: Map<
@@ -603,8 +604,9 @@ async function handleLegacyGroupUpdate(latestEnvelopeTimestamp: number) {
     const members = fromWrapper.members.map(m => m.pubkeyHex);
     const admins = fromWrapper.members.filter(m => m.isAdmin).map(m => m.pubkeyHex);
 
-    // NOTE some existing groups might not have a joinedAtSeconds and we need a truthy fallback value in order to poll and show up in the conversations list
-    const creationTimestamp = fromWrapper.joinedAtSeconds ? fromWrapper.joinedAtSeconds * 1000 : 1;
+    const creationTimestamp = fromWrapper.joinedAtSeconds
+      ? fromWrapper.joinedAtSeconds * 1000
+      : CONVERSATION.LAST_JOINED_FALLBACK_TIMESTAMP;
 
     // then for all the existing legacy group in the wrapper, we need to override the field of what we have in the DB with what is in the wrapper
     // We only set group admins on group creation

--- a/ts/session/constants.ts
+++ b/ts/session/constants.ts
@@ -62,6 +62,8 @@ export const CONVERSATION = {
   MAX_VOICE_MESSAGE_DURATION: 300,
   MAX_CONVO_UNREAD_COUNT: 999,
   MAX_GLOBAL_UNREAD_COUNT: 99, // the global one does not look good with 4 digits (999+) so we have a smaller one for it
+  /** NOTE some existing groups might not have joinedAtSeconds and we need a fallback value that is not falsy in order to poll and show up in the conversations list */
+  LAST_JOINED_FALLBACK_TIMESTAMP: 1,
 } as const;
 
 /**


### PR DESCRIPTION
If a group is missing a `joinedAt` value we use fallback value so we can poll for it and display it in the conversation list