### PR TITLE
fix: Font of the URL in the pop-up window

### DIFF
--- a/ts/components/dialog/SessionConfirm.tsx
+++ b/ts/components/dialog/SessionConfirm.tsx
@@ -225,7 +225,7 @@ export const showLinkVisitWarningDialog = (urlToOpen: string, dispatch: Dispatch
   dispatch(
     updateConfirmModal({
       title: window.i18n('linkVisitWarningTitle'),
-      message: window.i18n('linkVisitWarningMessage', [urlToOpen]),
+      message: window.i18n('linkVisitWarningMessage', [`<a href="#"  style="font-style: italic; color:#ffffff ">${urlToOpen}</a>`]),
       okText: window.i18n('open'),
       okTheme: SessionButtonColor.Primary,
       cancelText: window.i18n('editMenuCopy'),


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/oxen-io/session-desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/oxen-io/session-desktop/blob/master/CONTRIBUTING.md)

### Contributor checklist:

- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/oxen-io/session-desktop/tree/clearnet) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/oxen-io/session-desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description
Wrapped the `urlToOpen` into a anchor tag to be able to make it italics and underlined.

![image](https://github.com/user-attachments/assets/8f78afb7-4173-4277-9cfe-7aeefb006cf1)

Fix for issue:     oxen-io/session-desktop-temp#67
 
<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/loki-project/loki-messenger/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes oxen-io/session-desktop#222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
