### PR TITLE
chore: update package.json version to 1.13.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "session-desktop",
   "productName": "Session",
   "description": "Private messaging from your desktop",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "license": "GPL-3.0",
   "author": {
     "name": "Oxen Labs",


### PR DESCRIPTION
release branches are now protected so we should bump the version on `unstable` before creating the release branch