### PR TITLE
fix: send approved message only when previously unapproved

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -118,7 +118,7 @@ jobs:
   # We want a mac arm64 build, and according to this https://github.com/actions/runner-images#available-images macos-14 is always arm64
   # macos-14 is disabled for now as we hit our free tier limit for macos builds
   build_macos_x64:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       MAC_CERTIFICATE: ${{ secrets.MAC_CERTIFICATE }}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "session-desktop",
   "productName": "Session",
   "description": "Private messaging from your desktop",
-  "version": "1.14.1",
+  "version": "1.14.3",
   "license": "GPL-3.0",
   "author": {
     "name": "Oxen Labs",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/oxen-io/session-desktop.git"
+    "url": "https://github.com/session-foundation/session-desktop.git"
   },
   "main": "ts/mains/main_node.js",
   "resolutions": {

--- a/ts/interactions/conversationInteractions.ts
+++ b/ts/interactions/conversationInteractions.ts
@@ -91,7 +91,7 @@ export async function unblockConvoById(conversationId: string) {
 export const approveConvoAndSendResponse = async (conversationId: string) => {
   const convoToApprove = getConversationController().get(conversationId);
 
-  if (!convoToApprove) {
+  if (!convoToApprove || convoToApprove.isApproved()) {
     window?.log?.info('Conversation is already approved.');
     return;
   }

--- a/ts/session/utils/calling/CallManager.ts
+++ b/ts/session/utils/calling/CallManager.ts
@@ -35,6 +35,7 @@ import { MessageSender } from '../../sending';
 import { getIsRinging } from '../RingingManager';
 import { getBlackSilenceMediaStream } from './Silence';
 import { ed25519Str } from '../String';
+import { sleepFor } from '../Promise';
 
 export type InputItem = { deviceId: string; label: string };
 
@@ -534,6 +535,10 @@ export async function USER_callRecipient(recipient: string) {
   calledConvo.set('active_at', Date.now()); // addSingleOutgoingMessage does the commit for us on the convo
   await calledConvo.unhideIfNeeded(false);
   weAreCallerOnCurrentCall = true;
+  // Not ideal, but also temporary (see you in 2 years).
+  // We need to make sure the preoffer AND the messageRequestResponse sent in
+  // approveConvoAndSendResponse have different timestamps, as iOS will throw an error otherwise
+  await sleepFor(2);
 
   // initiating a call is analogous to sending a message request
   await approveConvoAndSendResponse(recipient);


### PR DESCRIPTION
This will be the last PR merged to oxen-io, and also the last release. Everything else has to be made to the session-foundation repo